### PR TITLE
Make a validate() method

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -4,6 +4,8 @@ const transformContent = require('./transform-content')
 const generateIndexes = require('./generate-indexes')
 
 const transform = (inputObjs, options) => {
+  validate(inputObjs)
+
   const contentObjs = inputObjs.map(inputObj => {
     if (path.extname(inputObj.relativePath) === '.md') {
       return transformContent(inputObj, options)
@@ -18,3 +20,12 @@ const transform = (inputObjs, options) => {
 }
 
 module.exports = transform
+
+const validate = (inputObjs) => {
+  if (!Array.isArray(inputObjs)) throw new Error('First arg to transform() must be an array')
+
+  inputObjs.map(inputObj => {
+    if (typeof inputObj.raw === 'undefined') throw new Error('All objects in input array must have a .raw property')
+    if (typeof inputObj.relativePath === 'undefined') throw new Error('All objects in input array must have a .relativePath property')
+  })
+}

--- a/test/transform/transform.test.js
+++ b/test/transform/transform.test.js
@@ -11,4 +11,24 @@ describe('Transform method', () => {
 
     expect(result).toEqual(expect.arrayContaining([notMdObj]))
   })
+
+  it('throws an error when first arg is undefined', () => {
+    expect(() => {
+      transform()
+    }).toThrow('First arg to transform() must be an array')
+  })
+
+  it('throws an error when the input array has an object that does not have a \'relativePath\'', () => {
+    const objWithoutRelativePath = { raw: '', path: '' }
+    expect(() => {
+      transform([objWithoutRelativePath])
+    }).toThrow('All objects in input array must have a .relativePath property')
+  })
+
+  it('throws an error when the input array has an object that does not have a \'raw\'', () => {
+    const objWithoutRaw = { roar: '', relativePath: '' }
+    expect(() => {
+      transform([objWithoutRaw])
+    }).toThrow('All objects in input array must have a .raw property')
+  })
 })


### PR DESCRIPTION
🧐 What?
Adds validation of the first arg to transform().

Why:
This is an entry point to the library - so provide clear errors when input is wrong.



