### PR TITLE
add branch config to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: node_js
 node_js:
 - 10
 
+branches:
+  only:
+    - master
+
 before_deploy: npm run make-package && cd package # cd so that the default use of 'npm publish' by this provider deploys/publishes the right files
 
 deploy:


### PR DESCRIPTION
🧐 What?

Set travis to only build for events on the master branch.

🛠 How

Added
"
branches:
  only:
    - master
"
to the root of the .travis.yml file.
