### PR TITLE
fix the markdown to html link conversion

### DIFF
--- a/src/markdown-to-html-parser.js
+++ b/src/markdown-to-html-parser.js
@@ -2,9 +2,9 @@ const showdown = require('showdown')
 
 // there may be an option to enable this, but since we haven't found it here is a reg-ex
 // to convert links within a file from *.md to *.html
-const linkExtensionExtension = {
+const convertMdLinksToHtmlLinks = {
   type: 'output',
-  regex: /<a href="(.*).md">/g,
+  regex: /<a href="([^:]*).md">/g, // exclude colon, so external links aren't converted
   replace: '<a href="$1.html">'
 }
 
@@ -27,7 +27,7 @@ const bindings = Object.keys(classMap)
   }))
 
 const parser = new showdown.Converter({
-  extensions: [linkExtensionExtension, headingExtension, ...bindings]
+  extensions: [convertMdLinksToHtmlLinks, headingExtension, ...bindings]
 })
 
 parser.setFlavor('github')

--- a/test/transform/markdown-to-html-parser.test.js
+++ b/test/transform/markdown-to-html-parser.test.js
@@ -40,4 +40,14 @@ describe('Markdown Parser', () => {
 
     expect(actual).toEqual(expected)
   })
+
+  it('doesn\'t break absolute links', () => {
+    const markdown = '[here](https://bbc.co.uk/docs/user/publishing-your-repo.md)'
+
+    const actual = parseToHtml(markdown)
+
+    const expected = '<p><a href="https://bbc.co.uk/docs/user/publishing-your-repo.md">here</a></p>'
+
+    expect(actual).toEqual(expected)
+  })
 })


### PR DESCRIPTION
🧐 What?
Fixed the markdown to html link conversion - external links to markdown files were broken. 

🛠 How
Previously if you clicked on a link within a file it was unable to open the html file, because ideally it should have been a markdown file. We made a new test and amended the convertMdLinksToHtmlLinks function to fix it! 

