### PR TITLE
GH-18: Fix file listing is incorrect

### DIFF
--- a/src/helpers/filter-files-in-dir.js
+++ b/src/helpers/filter-files-in-dir.js
@@ -4,10 +4,14 @@ function sortByDate (a, b) {
   return a.match(dateRegex) && b.match(dateRegex) ? b.localeCompare(a) : a.localeCompare(b)
 }
 
+function isFileInCurrentDir (filePath, directory) {
+  return (filePath.replace(directory, '').match(/\//g) || []).length <= 1
+}
+
 function filterFilesInDir (filePaths, directory) {
   return filePaths.filter(filePath => {
     return directory // directory = '' is falsy
-      ? filePath.startsWith(directory) && (filePath.replace(directory, '').match(/\//g) || []).length <= 1
+      ? filePath.startsWith(directory) && isFileInCurrentDir(filePath, directory)
       : !filePath.includes('/') // returns true for files in root directory
   })
 }

--- a/src/helpers/filter-files-in-dir.js
+++ b/src/helpers/filter-files-in-dir.js
@@ -7,7 +7,7 @@ function sortByDate (a, b) {
 function filterFilesInDir (filePaths, directory) {
   return filePaths.filter(filePath => {
     return directory // directory = '' is falsy
-      ? filePath.startsWith(directory)
+      ? filePath.startsWith(directory) && (filePath.replace(directory, '').match(/\//g) || []).length <= 1
       : !filePath.includes('/') // returns true for files in root directory
   })
 }

--- a/test/unit/__snapshots__/generate-indexes.test.js.snap
+++ b/test/unit/__snapshots__/generate-indexes.test.js.snap
@@ -1,5 +1,308 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Generate Indexes with the correct html The correct links are included in the raw output 1`] = `
+<html lang="en"
+      style="min-height:100vh"
+      data-reactroot
+>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible"
+          content="IE=edge"
+    >
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1"
+    >
+    <title>
+      Morty Docs
+    </title>
+    <link rel="stylesheet"
+          href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+          integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
+          crossorigin="anonymous"
+    >
+    <link rel="stylesheet"
+          href="https://use.fontawesome.com/releases/v5.8.1/css/all.css"
+          integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf"
+          crossorigin="anonymous"
+    >
+  </head>
+  <body style="min-height:100vh">
+    <div style="min-height:75vh;padding-bottom:20px">
+      <div class="container"
+           style="border:none;border-radius:0;background-color:#000;min-height:60px;margin-bottom:0;width:100%;padding-right:5px;padding-left:5px"
+      >
+        <div class="row col-md-12"
+             style="width:100%;padding-top:10px;padding-right:0px;padding-left:25px"
+        >
+          <h3 class="col-md-4"
+              style="text-align:left;padding-right:0px;padding-bottom:20px;color:#fff"
+          >
+            Morty-Docs
+          </h3>
+        </div>
+      </div>
+      <div class="container"
+           style="margin-top:10px"
+      >
+        <div class="row col-md-8 col-md-offset-2">
+          <ul class="list-unstyled">
+            <li class="index-list"
+                style="font-size:1.6em;border-bottom:solid black 1px;margin-bottom:10px"
+            >
+              <a href="bar/index.html">
+                <i class="fas fa-folder-open">
+                </i>
+                <span style="margin-left:5px">
+                  bar
+                </span>
+              </a>
+            </li>
+            <li class="index-list"
+                style="font-size:1.6em;border-bottom:solid black 1px;margin-bottom:10px"
+            >
+              <a href="bar/qux/index.html">
+                <i class="fas fa-folder-open">
+                </i>
+                <span style="margin-left:5px">
+                  bar/qux
+                </span>
+              </a>
+            </li>
+            <li class="index-list"
+                style="font-size:1.6em;border-bottom:solid black 1px;margin-bottom:10px"
+            >
+              <a href="foo.html">
+                <i class="fas fa-file-alt">
+                </i>
+                <span style="margin-left:5px">
+                  foo.html
+                </span>
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <footer style="bottom:0;width:100%;background-color:#f5f5f5;padding:0 15px;box-sizing:border-box;min-height:25vh;position:relative"
+            class="footer"
+    >
+      <div style="padding:1em 0 2em 0"
+           class="container"
+      >
+        <div class="row">
+          <div style="text-align:center"
+               class="col-md-4 col-md-offset-4"
+          >
+            <h3>
+              What is Morty-Docs?
+            </h3>
+            <p>
+              Link to
+              <a href="https://github.com/bbc/morty-docs">
+                Morty-docs
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>
+`;
+
+exports[`Generate Indexes with the correct html The correct links are included in the raw output 2`] = `
+<html lang="en"
+      style="min-height:100vh"
+      data-reactroot
+>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible"
+          content="IE=edge"
+    >
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1"
+    >
+    <title>
+      Morty Docs
+    </title>
+    <link rel="stylesheet"
+          href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+          integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
+          crossorigin="anonymous"
+    >
+    <link rel="stylesheet"
+          href="https://use.fontawesome.com/releases/v5.8.1/css/all.css"
+          integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf"
+          crossorigin="anonymous"
+    >
+  </head>
+  <body style="min-height:100vh">
+    <div style="min-height:75vh;padding-bottom:20px">
+      <div class="container"
+           style="border:none;border-radius:0;background-color:#000;min-height:60px;margin-bottom:0;width:100%;padding-right:5px;padding-left:5px"
+      >
+        <div class="row col-md-12"
+             style="width:100%;padding-top:10px;padding-right:0px;padding-left:25px"
+        >
+          <h3 class="col-md-4"
+              style="text-align:left;padding-right:0px;padding-bottom:20px;color:#fff"
+          >
+            Morty-Docs
+          </h3>
+        </div>
+      </div>
+      <div class="container"
+           style="margin-top:10px"
+      >
+        <div class="row col-md-8 col-md-offset-2">
+          <ul class="list-unstyled">
+            <li class="index-list"
+                style="font-size:1.6em;border-bottom:solid black 1px;margin-bottom:10px"
+            >
+              <a href="qux/index.html">
+                <i class="fas fa-folder-open">
+                </i>
+                <span style="margin-left:5px">
+                  qux
+                </span>
+              </a>
+            </li>
+            <li class="index-list"
+                style="font-size:1.6em;border-bottom:solid black 1px;margin-bottom:10px"
+            >
+              <a href="baz.html">
+                <i class="fas fa-file-alt">
+                </i>
+                <span style="margin-left:5px">
+                  baz.html
+                </span>
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <footer style="bottom:0;width:100%;background-color:#f5f5f5;padding:0 15px;box-sizing:border-box;min-height:25vh;position:relative"
+            class="footer"
+    >
+      <div style="padding:1em 0 2em 0"
+           class="container"
+      >
+        <div class="row">
+          <div style="text-align:center"
+               class="col-md-4 col-md-offset-4"
+          >
+            <h3>
+              What is Morty-Docs?
+            </h3>
+            <p>
+              Link to
+              <a href="https://github.com/bbc/morty-docs">
+                Morty-docs
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>
+`;
+
+exports[`Generate Indexes with the correct html The correct links are included in the raw output 3`] = `
+<html lang="en"
+      style="min-height:100vh"
+      data-reactroot
+>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible"
+          content="IE=edge"
+    >
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1"
+    >
+    <title>
+      Morty Docs
+    </title>
+    <link rel="stylesheet"
+          href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+          integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
+          crossorigin="anonymous"
+    >
+    <link rel="stylesheet"
+          href="https://use.fontawesome.com/releases/v5.8.1/css/all.css"
+          integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf"
+          crossorigin="anonymous"
+    >
+  </head>
+  <body style="min-height:100vh">
+    <div style="min-height:75vh;padding-bottom:20px">
+      <div class="container"
+           style="border:none;border-radius:0;background-color:#000;min-height:60px;margin-bottom:0;width:100%;padding-right:5px;padding-left:5px"
+      >
+        <div class="row col-md-12"
+             style="width:100%;padding-top:10px;padding-right:0px;padding-left:25px"
+        >
+          <h3 class="col-md-4"
+              style="text-align:left;padding-right:0px;padding-bottom:20px;color:#fff"
+          >
+            Morty-Docs
+          </h3>
+        </div>
+      </div>
+      <div class="container"
+           style="margin-top:10px"
+      >
+        <div class="row col-md-8 col-md-offset-2">
+          <ul class="list-unstyled">
+            <li class="index-list"
+                style="font-size:1.6em;border-bottom:solid black 1px;margin-bottom:10px"
+            >
+              <a href="qar.html">
+                <i class="fas fa-file-alt">
+                </i>
+                <span style="margin-left:5px">
+                  qar.html
+                </span>
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <footer style="bottom:0;width:100%;background-color:#f5f5f5;padding:0 15px;box-sizing:border-box;min-height:25vh;position:relative"
+            class="footer"
+    >
+      <div style="padding:1em 0 2em 0"
+           class="container"
+      >
+        <div class="row">
+          <div style="text-align:center"
+               class="col-md-4 col-md-offset-4"
+          >
+            <h3>
+              What is Morty-Docs?
+            </h3>
+            <p>
+              Link to
+              <a href="https://github.com/bbc/morty-docs">
+                Morty-docs
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>
+`;
+
 exports[`Generate Indexes with the correct html to match snapshot with a content title 1`] = `
 <html lang="en"
       style="min-height:100vh"

--- a/test/unit/generate-indexes.test.js
+++ b/test/unit/generate-indexes.test.js
@@ -52,32 +52,9 @@ describe('Generate Indexes with the correct html', () => {
 
     const actual = generateIndexes(input, { repoName: 'some-repo' })
 
-    const expectedRootIndexLinks = [
-      '<a href="bar/index.html">',
-      '<a href="bar/qux/index.html">',
-      '<a href="foo.html">'
-    ]
-
-    const expectedBarIndexLinks = [
-      '<a href="baz.html">',
-      '<a href="qux/index.html">'
-    ]
-
-    const expectedQuxIndexLinks = [
-      '<a href="qar.html">'
-    ]
-
-    expectedRootIndexLinks.forEach(link => {
-      expect(actual[0].raw.toString()).toContain(link)
-    })
-
-    expectedBarIndexLinks.forEach(link => {
-      expect(actual[1].raw.toString()).toContain(link)
-    })
-
-    expectedQuxIndexLinks.forEach(link => {
-      expect(actual[2].raw.toString()).toContain(link)
-    })
+    expect(actual[0].raw.toString()).toMatchSnapshot()
+    expect(actual[1].raw.toString()).toMatchSnapshot()
+    expect(actual[2].raw.toString()).toMatchSnapshot()
   })
 
   it('to match snapshot with a content title', () => {


### PR DESCRIPTION
🧐 What?

Files in subfolders below the root were being added to the index of the
parent folder. This was due to the filter allowing every relative path for files
starting with the directory.

🛠 How
This commit restricts the filter to only take the files within the current
folder.

Co-authored-by: Adam Cook <adam.cook@bbc.co.uk>
Co-authored-by: Pete Rwatschew <pete.rwatschew@bbc.co.uk>