### PR TITLE
fix bug in link conversion

### DIFF
--- a/src/markdown-to-html-parser.js
+++ b/src/markdown-to-html-parser.js
@@ -4,7 +4,7 @@ const showdown = require('showdown')
 // to convert links within a file from *.md to *.html
 const convertMdLinksToHtmlLinks = {
   type: 'output',
-  regex: /<a href="([^:]*).md">/g, // exclude colon, so external links aren't converted
+  regex: /<a href="([^:\n]*).md">/g, // exclude colon, so external links aren't converted
   replace: '<a href="$1.html">'
 }
 

--- a/test/unit/markdown-to-html-parser.test.js
+++ b/test/unit/markdown-to-html-parser.test.js
@@ -32,21 +32,21 @@ describe('Markdown Parser', () => {
   })
 
   it('creates an html link from an md link', () => {
-    const markdown = '[here](./docs/user/publishing-your-repo.md)'
+    const markdown = '[here](./docs/user/publishing-your-repo.md)\n[here](./docs/user/publishing-another-repo.md)'
 
     const actual = parseToHtml(markdown)
 
-    const expected = '<p><a href="./docs/user/publishing-your-repo.html">here</a></p>'
+    const expected = '<p><a href="./docs/user/publishing-your-repo.html">here</a><br />\n<a href="./docs/user/publishing-another-repo.html">here</a></p>'
 
     expect(actual).toEqual(expected)
   })
 
   it('doesn\'t break absolute links', () => {
-    const markdown = '[here](https://bbc.co.uk/docs/user/publishing-your-repo.md)'
+    const markdown = '[here](https://bbc.co.uk/docs/user/publishing-your-repo.md)\n[here](https://bbc.co.uk/docs/user/publishing-another-repo.md)'
 
     const actual = parseToHtml(markdown)
 
-    const expected = '<p><a href="https://bbc.co.uk/docs/user/publishing-your-repo.md">here</a></p>'
+    const expected = '<p><a href="https://bbc.co.uk/docs/user/publishing-your-repo.md">here</a><br />\n<a href="https://bbc.co.uk/docs/user/publishing-another-repo.md">here</a></p>'
 
     expect(actual).toEqual(expected)
   })


### PR DESCRIPTION
🧐 What?

We have fixed the bug in the link conversion - raised here: #20 

🛠 How

This amends the reg ex to include new line characters, so that lists of links will be converted. 

🐞 Related issue: 
#20 
