### PR TITLE
Update dir walking to remove nested folders from links

### DIFF
--- a/src/generate-indexes.js
+++ b/src/generate-indexes.js
@@ -5,11 +5,12 @@ const filterFilesInDirectory = require('./helpers/filter-files-in-dir')
 const filterDirectoriesInDirectory = require('./helpers/filter-dirs-in-dir')
 
 const generateIndex = (htmlFilePaths, subDirPaths, contentTitle) => {
-  const subDirLinks = subDirPaths.map(dirPath => ({
+  const subDirLinks = subDirPaths.filter(dirPath => !dirPath.includes('/')).map(dirPath => ({
     link: `${dirPath}/index.html`,
     text: dirPath,
     iconClass: 'fas fa-folder-open'
-  }))
+  })
+  )
 
   const fileLinks = htmlFilePaths.map(filePath => {
     const text = path.basename(filePath)

--- a/src/generate-transform-input.js
+++ b/src/generate-transform-input.js
@@ -7,7 +7,7 @@ const generateTransformInput = (dir) => {
   return readdir(dir).then(files => {
     return files.map(file => {
       return {
-        relativePath: file.toString().replace(dir, ''),
+        relativePath: file.toString(),
         raw: fs.readFileSync(file)
       }
     })

--- a/src/helpers/get-directory-paths.js
+++ b/src/helpers/get-directory-paths.js
@@ -1,13 +1,3 @@
-// module.exports = filePaths => [...new Set(filePaths.map(path => {
-//   const lastSlashIndex = path.lastIndexOf('/')
-
-//   const split = path.split('/')
-//   console.log(split)
-//   // if the filePath contains a '/', then return just the directory
-//   // otherwise, return '' (i.e. this is the root)
-//   return lastSlashIndex !== -1 ? path.slice(0, lastSlashIndex) : ''
-// }))]
-
 const getDirectoryPaths = (filePaths) => {
   const dirPaths = filePaths.map(path => {
     // file = SomeOtherDir/AnotherDir/AnotherNestedDir/file.html

--- a/src/helpers/get-directory-paths.js
+++ b/src/helpers/get-directory-paths.js
@@ -1,6 +1,38 @@
-module.exports = filePaths => [...new Set(filePaths.map(path => {
-  const lastSlashIndex = path.lastIndexOf('/')
-  // if the filePath contains a '/', then return just the directory
-  // otherwise, return '' (i.e. this is the root)
-  return lastSlashIndex !== -1 ? path.slice(0, lastSlashIndex) : ''
-}))]
+// module.exports = filePaths => [...new Set(filePaths.map(path => {
+//   const lastSlashIndex = path.lastIndexOf('/')
+
+//   const split = path.split('/')
+//   console.log(split)
+//   // if the filePath contains a '/', then return just the directory
+//   // otherwise, return '' (i.e. this is the root)
+//   return lastSlashIndex !== -1 ? path.slice(0, lastSlashIndex) : ''
+// }))]
+
+const getDirectoryPaths = (filePaths) => {
+  const dirPaths = filePaths.map(path => {
+    // file = SomeOtherDir/AnotherDir/AnotherNestedDir/file.html
+    if (!path.includes('/')) return '' // if file is not in the directory, return '', as this is the root
+
+    const splitPaths = path.split('/') // => [ 'SomeOtherDir', 'AnotherDir', 'AnotherNestedDir', 'File1.html' ]
+    splitPaths.pop() // remove file.html
+
+    const allDirs = splitPaths.map((splitPath, index) => {
+      const newPath = joinPathParts(splitPaths, index)
+      return newPath
+    })
+
+    return allDirs
+  })
+
+  return [...new Set(dirPaths.flat())]
+}
+
+const joinPathParts = (pathsArray, end) => {
+  if (end === 0) {
+    return pathsArray[0]
+  }
+  end++
+  return pathsArray.slice(0, end).join('/')
+}
+
+module.exports = getDirectoryPaths

--- a/test/unit/__snapshots__/generate-indexes.test.js.snap
+++ b/test/unit/__snapshots__/generate-indexes.test.js.snap
@@ -50,33 +50,33 @@ exports[`Generate Indexes with the correct html The correct links are included i
             <li class="index-list"
                 style="font-size:1.6em;border-bottom:solid black 1px;margin-bottom:10px"
             >
-              <a href="bar/index.html">
+              <a href="folder/index.html">
                 <i class="fas fa-folder-open">
                 </i>
                 <span style="margin-left:5px">
-                  bar
+                  folder
                 </span>
               </a>
             </li>
             <li class="index-list"
                 style="font-size:1.6em;border-bottom:solid black 1px;margin-bottom:10px"
             >
-              <a href="bar/qux/index.html">
+              <a href="docs/index.html">
                 <i class="fas fa-folder-open">
                 </i>
                 <span style="margin-left:5px">
-                  bar/qux
+                  docs
                 </span>
               </a>
             </li>
             <li class="index-list"
                 style="font-size:1.6em;border-bottom:solid black 1px;margin-bottom:10px"
             >
-              <a href="foo.html">
+              <a href="rootFile.html">
                 <i class="fas fa-file-alt">
                 </i>
                 <span style="margin-left:5px">
-                  foo.html
+                  rootFile.html
                 </span>
               </a>
             </li>
@@ -162,22 +162,11 @@ exports[`Generate Indexes with the correct html The correct links are included i
             <li class="index-list"
                 style="font-size:1.6em;border-bottom:solid black 1px;margin-bottom:10px"
             >
-              <a href="qux/index.html">
-                <i class="fas fa-folder-open">
-                </i>
-                <span style="margin-left:5px">
-                  qux
-                </span>
-              </a>
-            </li>
-            <li class="index-list"
-                style="font-size:1.6em;border-bottom:solid black 1px;margin-bottom:10px"
-            >
-              <a href="baz.html">
+              <a href="nestedFile.html">
                 <i class="fas fa-file-alt">
                 </i>
                 <span style="margin-left:5px">
-                  baz.html
+                  nestedFile.html
                 </span>
               </a>
             </li>
@@ -263,11 +252,101 @@ exports[`Generate Indexes with the correct html The correct links are included i
             <li class="index-list"
                 style="font-size:1.6em;border-bottom:solid black 1px;margin-bottom:10px"
             >
-              <a href="qar.html">
+              <a href="arch/index.html">
+                <i class="fas fa-folder-open">
+                </i>
+                <span style="margin-left:5px">
+                  arch
+                </span>
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <footer style="bottom:0;width:100%;background-color:#f5f5f5;padding:0 15px;box-sizing:border-box;min-height:25vh;position:relative"
+            class="footer"
+    >
+      <div style="padding:1em 0 2em 0"
+           class="container"
+      >
+        <div class="row">
+          <div style="text-align:center"
+               class="col-md-4 col-md-offset-4"
+          >
+            <h3>
+              What is Morty-Docs?
+            </h3>
+            <p>
+              Link to
+              <a href="https://github.com/bbc/morty-docs">
+                Morty-docs
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>
+`;
+
+exports[`Generate Indexes with the correct html The correct links are included in the raw output 4`] = `
+<html lang="en"
+      style="min-height:100vh"
+      data-reactroot
+>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible"
+          content="IE=edge"
+    >
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1"
+    >
+    <title>
+      Morty Docs
+    </title>
+    <link rel="stylesheet"
+          href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+          integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
+          crossorigin="anonymous"
+    >
+    <link rel="stylesheet"
+          href="https://use.fontawesome.com/releases/v5.8.1/css/all.css"
+          integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf"
+          crossorigin="anonymous"
+    >
+  </head>
+  <body style="min-height:100vh">
+    <div style="min-height:75vh;padding-bottom:20px">
+      <div class="container"
+           style="border:none;border-radius:0;background-color:#000;min-height:60px;margin-bottom:0;width:100%;padding-right:5px;padding-left:5px"
+      >
+        <div class="row col-md-12"
+             style="width:100%;padding-top:10px;padding-right:0px;padding-left:25px"
+        >
+          <h3 class="col-md-4"
+              style="text-align:left;padding-right:0px;padding-bottom:20px;color:#fff"
+          >
+            Morty-Docs
+          </h3>
+        </div>
+      </div>
+      <div class="container"
+           style="margin-top:10px"
+      >
+        <div class="row col-md-8 col-md-offset-2">
+          <ul class="list-unstyled">
+            <li class="index-list"
+                style="font-size:1.6em;border-bottom:solid black 1px;margin-bottom:10px"
+            >
+              <a href="furtherNestedFile.html">
                 <i class="fas fa-file-alt">
                 </i>
                 <span style="margin-left:5px">
-                  qar.html
+                  furtherNestedFile.html
                 </span>
               </a>
             </li>

--- a/test/unit/generate-indexes.test.js
+++ b/test/unit/generate-indexes.test.js
@@ -59,6 +59,27 @@ describe('Generate Indexes with the correct paths', () => {
 
     expect(actual).toEqual(expected)
   })
+
+  it('generates indexes for every other directory in path', () => {
+    const input = [{
+      relativePath: 'default-md-files/docs/arch/someMDFile.html'
+    }]
+
+    const actual = generateIndexes(input, { repoName: 'some-repo' })
+
+    const expected = [{
+      relativePath: 'default-md-files/index.html',
+      raw: expect.anything()
+    }, {
+      relativePath: 'default-md-files/docs/index.html',
+      raw: expect.anything()
+    }, {
+      relativePath: 'default-md-files/docs/arch/index.html',
+      raw: expect.anything()
+    }]
+
+    expect(actual).toEqual(expected)
+  })
 })
 
 describe('Generate Indexes with the correct html', () => {

--- a/test/unit/generate-indexes.test.js
+++ b/test/unit/generate-indexes.test.js
@@ -2,7 +2,7 @@ const generateIndexes = require('../../src/generate-indexes.js')
 
 describe('Generate Indexes with the correct paths', () => {
   it('for a top level index page', () => {
-    const input = [{ relativePath: 'foo.html' }]
+    const input = [{ relativePath: 'someRootFile.html' }]
 
     const actual = generateIndexes(input, { repoName: 'some-repo' })
 
@@ -16,11 +16,11 @@ describe('Generate Indexes with the correct paths', () => {
 
   it('for multiple index pages', () => {
     const input = [{
-      relativePath: 'foo.html'
+      relativePath: 'someRootFile.html'
     }, {
-      relativePath: 'bar/baz.html'
+      relativePath: 'someFolder/file.html'
     }, {
-      relativePath: 'bar/qux/qar.html'
+      relativePath: 'someOtherFolder/file.html'
     }]
 
     const actual = generateIndexes(input, { repoName: 'some-repo' })
@@ -29,10 +29,31 @@ describe('Generate Indexes with the correct paths', () => {
       relativePath: 'index.html',
       raw: expect.anything()
     }, {
-      relativePath: 'bar/index.html',
+      relativePath: 'someFolder/index.html',
       raw: expect.anything()
     }, {
-      relativePath: 'bar/qux/index.html',
+      relativePath: 'someOtherFolder/index.html',
+      raw: expect.anything()
+    }]
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('generates indexes for every directory in path', () => {
+    const input = [{
+      relativePath: 'someFolder/someOtherFolder/docs/file.html'
+    }]
+
+    const actual = generateIndexes(input, { repoName: 'some-repo' })
+
+    const expected = [{
+      relativePath: 'someFolder/index.html',
+      raw: expect.anything()
+    }, {
+      relativePath: 'someFolder/someOtherFolder/index.html',
+      raw: expect.anything()
+    }, {
+      relativePath: 'someFolder/someOtherFolder/docs/index.html',
       raw: expect.anything()
     }]
 
@@ -40,34 +61,14 @@ describe('Generate Indexes with the correct paths', () => {
   })
 })
 
-it('for indexes within a nested folder of the same name of the config folder', () => {
-  const input = [{
-    relativePath: 'docs/arch/foo.html'
-  }, {
-    relativePath: 'services/service/docs/arch/baz.html'
-  }]
-
-  const actual = generateIndexes(input, { repoName: 'some-repo' })
-
-  const expected = [{
-    relativePath: 'docs/arch/index.html',
-    raw: expect.anything()
-  }, {
-    relativePath: 'services/service/docs/arch/index.html',
-    raw: expect.anything()
-  }]
-
-  expect(actual).toEqual(expected)
-})
-
 describe('Generate Indexes with the correct html', () => {
   it('The correct links are included in the raw output', () => {
     const input = [{
-      relativePath: 'foo.html'
+      relativePath: 'rootFile.html'
     }, {
-      relativePath: 'bar/baz.html'
+      relativePath: 'folder/nestedFile.html'
     }, {
-      relativePath: 'bar/qux/qar.html'
+      relativePath: 'docs/arch/furtherNestedFile.html'
     }]
 
     const actual = generateIndexes(input, { repoName: 'some-repo' })
@@ -75,6 +76,7 @@ describe('Generate Indexes with the correct html', () => {
     expect(actual[0].raw.toString()).toMatchSnapshot()
     expect(actual[1].raw.toString()).toMatchSnapshot()
     expect(actual[2].raw.toString()).toMatchSnapshot()
+    expect(actual[3].raw.toString()).toMatchSnapshot()
   })
 
   it('to match snapshot with a content title', () => {

--- a/test/unit/generate-transform-input.test.js
+++ b/test/unit/generate-transform-input.test.js
@@ -12,16 +12,16 @@ describe('Generate transform input', () => {
   it('creates a correctly structured array of file objects from a directory ending in a slash', async () => {
     const expected = [
       {
-        relativePath: 'some/path/tofile.md',
+        relativePath: 'someDirectory/some/path/tofile.md',
         raw: 'some text in a file'
       },
       {
-        relativePath: 'another/path/tofile.md',
+        relativePath: 'someDirectory/another/path/tofile.md',
         raw: 'some text in a file'
       }
     ]
 
-    const actual = await generateTransformInput('someDirectory/')
+    const actual = await generateTransformInput('tmp/someRepo/', 'someDirectory/')
 
     expect(actual).toEqual(expected)
   })
@@ -29,16 +29,16 @@ describe('Generate transform input', () => {
   it('creates a correctly structured array of file objects from a directory that does not end in a slash', async () => {
     const expected = [
       {
-        relativePath: 'some/path/tofile.md',
+        relativePath: 'someDirectory/some/path/tofile.md',
         raw: 'some text in a file'
       },
       {
-        relativePath: 'another/path/tofile.md',
+        relativePath: 'someDirectory/another/path/tofile.md',
         raw: 'some text in a file'
       }
     ]
 
-    const actual = await generateTransformInput('someDirectory')
+    const actual = await generateTransformInput('tmp/someRepo', 'someDirectory')
 
     expect(actual).toEqual(expected)
   })

--- a/test/unit/generate-transform-input.test.js
+++ b/test/unit/generate-transform-input.test.js
@@ -5,23 +5,23 @@ const fs = require('fs')
 jest.mock('recursive-readdir')
 jest.mock('fs')
 
-readdir.mockImplementation(() => Promise.resolve(['someDirectory/some/path/tofile.md', 'someDirectory/another/path/tofile.md']))
+readdir.mockImplementation(() => Promise.resolve(['someRepo/someDirectory/some/path/tofile.md', 'someRepo/someDirectory/another/path/tofile.md']))
 fs.readFileSync.mockImplementation(() => 'some text in a file')
 
 describe('Generate transform input', () => {
   it('creates a correctly structured array of file objects from a directory ending in a slash', async () => {
     const expected = [
       {
-        relativePath: 'someDirectory/some/path/tofile.md',
+        relativePath: 'someRepo/someDirectory/some/path/tofile.md',
         raw: 'some text in a file'
       },
       {
-        relativePath: 'someDirectory/another/path/tofile.md',
+        relativePath: 'someRepo/someDirectory/another/path/tofile.md',
         raw: 'some text in a file'
       }
     ]
 
-    const actual = await generateTransformInput('tmp/someRepo/', 'someDirectory/')
+    const actual = await generateTransformInput('someRepo/someDirectory/')
 
     expect(actual).toEqual(expected)
   })
@@ -29,16 +29,16 @@ describe('Generate transform input', () => {
   it('creates a correctly structured array of file objects from a directory that does not end in a slash', async () => {
     const expected = [
       {
-        relativePath: 'someDirectory/some/path/tofile.md',
+        relativePath: 'someRepo/someDirectory/some/path/tofile.md',
         raw: 'some text in a file'
       },
       {
-        relativePath: 'someDirectory/another/path/tofile.md',
+        relativePath: 'someRepo/someDirectory/another/path/tofile.md',
         raw: 'some text in a file'
       }
     ]
 
-    const actual = await generateTransformInput('tmp/someRepo', 'someDirectory')
+    const actual = await generateTransformInput('someRepo/someDirectory')
 
     expect(actual).toEqual(expected)
   })

--- a/test/unit/helpers/get-directory-paths.test.js
+++ b/test/unit/helpers/get-directory-paths.test.js
@@ -1,0 +1,23 @@
+const getDirectoryPaths = require('../../../src/helpers/get-directory-paths')
+
+describe('Filter files in directory', () => {
+  it('returns all stages of a directory path', () => {
+    const filePaths = [
+      'SomeFile.html',
+      'SomeDir/SomeNestedDir/File1.html',
+      'SomeDir/AnotherDir/AnotherNestedDir/File1.html'
+    ]
+
+    const expected = [
+      '',
+      'SomeDir',
+      'SomeDir/SomeNestedDir',
+      'SomeDir/AnotherDir',
+      'SomeDir/AnotherDir/AnotherNestedDir'
+    ]
+
+    const actual = getDirectoryPaths(filePaths)
+
+    expect(actual).toEqual(expected)
+  })
+})


### PR DESCRIPTION
🧐 What?

Generates an index.html for every directory within a path, instead of displaying them as: docs/arch/november/file.

🛠 How

Refactoring get-directory-paths.js to return every directory with the relative path it is passed, resulting in generate-indexes.js creating an index file for every folder.
