### PR TITLE
Fix base paths

### DIFF
--- a/run.js
+++ b/run.js
@@ -1,14 +1,18 @@
 const fsExtra = require('fs-extra')
 const { transform, generateTransformInput } = require('./build/src')
 
+const path = require('path')
+
 const directoryToConvert = JSON.parse(process.env.npm_config_argv).remain[0] || 'default-md-files'
+const resolvedPath = path.resolve(directoryToConvert)
 
 const mortyDocs = async () => {
-  const inputObjs = await generateTransformInput(directoryToConvert)
+  const inputObjs = await generateTransformInput(resolvedPath)
 
   const files = transform(inputObjs, { contentTitle: 'Content Title - located in run.js' })
 
   files.forEach(file => {
+    console.log(`file.relativePath: ${JSON.stringify(file.relativePath, null, 2)}`)
     let filePath = `www/${file.relativePath}`
     fsExtra.ensureFileSync(filePath)
     fsExtra.writeFileSync(filePath, file.raw)

--- a/run.js
+++ b/run.js
@@ -12,7 +12,6 @@ const mortyDocs = async () => {
   const files = transform(inputObjs, { contentTitle: 'Content Title - located in run.js' })
 
   files.forEach(file => {
-    console.log(`file.relativePath: ${JSON.stringify(file.relativePath, null, 2)}`)
     let filePath = `www/${file.relativePath}`
     fsExtra.ensureFileSync(filePath)
     fsExtra.writeFileSync(filePath, file.raw)

--- a/src/generate-transform-input.js
+++ b/src/generate-transform-input.js
@@ -1,13 +1,15 @@
 const readdir = require('recursive-readdir')
 const fs = require('fs')
+const path = require('path')
 
 const generateTransformInput = (dir) => {
-  dir = dir.endsWith('/') ? dir : `${dir}/`
+  const pathParts = path.parse(dir)
 
   return readdir(dir).then(files => {
     return files.map(file => {
+      console.log(`pathParts.dir: ${JSON.stringify(pathParts.dir, null, 2)}`)
       return {
-        relativePath: file.toString(),
+        relativePath: file.toString().replace(`${pathParts.dir}/`, ''),
         raw: fs.readFileSync(file)
       }
     })

--- a/test/unit/generate-transform-input.test.js
+++ b/test/unit/generate-transform-input.test.js
@@ -5,40 +5,48 @@ const fs = require('fs')
 jest.mock('recursive-readdir')
 jest.mock('fs')
 
-readdir.mockImplementation(() => Promise.resolve(['someRepo/someDirectory/some/path/tofile.md', 'someRepo/someDirectory/another/path/tofile.md']))
-fs.readFileSync.mockImplementation(() => 'some text in a file')
-
 describe('Generate transform input', () => {
-  it('creates a correctly structured array of file objects from a directory ending in a slash', async () => {
-    const expected = [
-      {
-        relativePath: 'someRepo/someDirectory/some/path/tofile.md',
-        raw: 'some text in a file'
-      },
-      {
-        relativePath: 'someRepo/someDirectory/another/path/tofile.md',
-        raw: 'some text in a file'
-      }
-    ]
+  beforeEach(() => {
+    readdir.mockImplementation(() => Promise.resolve([
+      '/tmp/someRepo/someDirectory/some/path/tofile.md',
+      '/tmp/someRepo/someDirectory/another/path/tofile.md'
+    ]))
+    fs.readFileSync.mockImplementation(() => 'some text in a file')
+  })
 
-    const actual = await generateTransformInput('someRepo/someDirectory/')
+  afterEach(() => {
+    readdir.mockRestore()
+    fs.readFileSync.mockRestore()
+  })
+
+  it('creates a correctly structured array of file objects from a directory ending in a slash', async () => {
+    const dir = '/tmp/someRepo/someDirectory/'
+
+    const expected = [{
+      relativePath: 'someDirectory/some/path/tofile.md',
+      raw: 'some text in a file'
+    }, {
+      relativePath: 'someDirectory/another/path/tofile.md',
+      raw: 'some text in a file'
+    }]
+
+    const actual = await generateTransformInput(dir)
 
     expect(actual).toEqual(expected)
   })
 
   it('creates a correctly structured array of file objects from a directory that does not end in a slash', async () => {
-    const expected = [
-      {
-        relativePath: 'someRepo/someDirectory/some/path/tofile.md',
-        raw: 'some text in a file'
-      },
-      {
-        relativePath: 'someRepo/someDirectory/another/path/tofile.md',
-        raw: 'some text in a file'
-      }
-    ]
+    const dir = '/tmp/someRepo/someDirectory'
 
-    const actual = await generateTransformInput('someRepo/someDirectory')
+    const expected = [{
+      relativePath: 'someDirectory/some/path/tofile.md',
+      raw: 'some text in a file'
+    }, {
+      relativePath: 'someDirectory/another/path/tofile.md',
+      raw: 'some text in a file'
+    }]
+
+    const actual = await generateTransformInput(dir)
 
     expect(actual).toEqual(expected)
   })


### PR DESCRIPTION
- This also changes 'run.js' to behave as it is intended to be used

🧐 What?

This fixes base paths being incorrectly used.

Previously, if we entered '/tmp/someRepo/docs' as the path, we would be returning '/tmp/someRepo/docs' as the path, rather than 'docs'.

🛠 How

We've started using node's built-in functions to handle path related manipulation