### PR TITLE
fix broke npm install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you do want to be able to have more control over the website which is publish
 
 ### Install
 
-`npm install --save morty-docs`
+`npm install --save bbc/morty-docs`
 
 ### Require
 


### PR DESCRIPTION
🧐 What?
fixes the current `npm install` instruction which is broken

🛠 How
by prefixing with the github organisation

👀 See
current error:
```
chesta02$ npm install --save morty-docs
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/morty-docs - Not found
npm ERR! 404
npm ERR! 404  'morty-docs@latest' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/chesta02/.npm/_logs/2020-04-08T10_13_27_085Z-debug.log
```
