### PR TITLE
Allow an optional base path to be supplied

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ const { generateTransformInput, transform } = require('@bbc/morty-docs')
 ```javascript
 const inputObjs = await generateTransformInput('a/folder/with/markdown-files')
 
-const outputObjs = transform(inputObjs,{ contentTitle: 'My Docs' })
+const outputObjs = transform(inputObjs,{ contentTitle: 'My Docs', basePath: '/path/my/docs/are/hosted/under' })
 ```
 
 - `transform()` can be used alone, but if your files are in a local
 directory the `generateTransformInput()` function is a convenience
-- the 2nd argument to transform() can *optionally* be used to provide a Title
-that is displayed on the generated index pages.
+- the 2nd argument to `transform()` can *optionally* be used to provide a Title
+that is displayed on the generated index pages and the base path below which your files will be served (this required to make markdown links starting with `/` work).
 
 - `outputObjs` will be an array of objects like this:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/morty-docs",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/morty-docs",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "To generate a static website from markdown documentation, to allow users to consume content in an easily accessible format",
   "main": "dist/index.js",
   "publishConfig": {

--- a/src/transform-content.js
+++ b/src/transform-content.js
@@ -6,17 +6,25 @@ const parseToHtml = require('./markdown-to-html-parser')
 
 const changeExtension = relPath => relPath.replace(/\.[^.]*$/, '.html') // \.[^.]*$  selects everything from end of string to first '.' character including the '.'
 
+const convertToHtml = ({ relativePath, raw }, options) => {
+  const textString = raw.toString()
+  const ext = path.extname(relativePath)
+
+  if (ext === '.asciidoc' || ext === '.adoc' || ext === '.asc') {
+    return asciidoctor.convert(textString)
+  }
+
+  return parseToHtml(textString, options)
+}
+
 const transformContent = (inputObj, options) => {
   const inputRelPath = inputObj.relativePath
-  const ext = path.extname(inputRelPath)
-  const parser = (ext === '.asciidoc' || ext === '.adoc' || ext === '.asc') ? asciidoctor.convert.bind(asciidoctor) : parseToHtml
-
+  const html = convertToHtml(inputObj, options)
   return {
     relativePath: changeExtension(inputRelPath),
     raw: renderMortyPage(
       inputRelPath,
-
-      parser(inputObj.raw.toString()),
+      html,
       options)
   }
 }

--- a/test/unit/__snapshots__/transform-content.test.js.snap
+++ b/test/unit/__snapshots__/transform-content.test.js.snap
@@ -319,7 +319,7 @@ exports[`Transform-content returns the correct html from AsciiDoc for a line of 
 </html>
 `;
 
-exports[`Transform-content returns the correct html from markdown for Markdown with a title and a link 1`] = `
+exports[`Transform-content returns the correct html from markdown for Markdown with a title and links 1`] = `
 <html lang="en"
       style="min-height:100vh"
       data-reactroot
@@ -364,7 +364,11 @@ exports[`Transform-content returns the correct html from markdown for Markdown w
         </h1>
         <p>
           <a href="docs/file-to-publish.html">
-            Link to MD in docs directory
+            Relative link to MD in docs directory
+          </a>
+          <br>
+          <a href="/morty-docs/some-repo/docs/file-to-publish.html">
+            Root link to MD in docs directory
           </a>
         </p>
       </div>

--- a/test/unit/transform-content-internals.test.js
+++ b/test/unit/transform-content-internals.test.js
@@ -18,14 +18,12 @@ describe('Transformed content passed to html parser is of correct type', () => {
   })
 })
 
-describe('', () => {
-  it('Passes the options to the html parser', () => {
-    const inputObj = {
-      relativePath: 'file-name.md',
-      raw: Buffer.from(`some text here`, 'utf-8')
-    }
+it('Passes the options to the html parser', () => {
+  const inputObj = {
+    relativePath: 'file-name.md',
+    raw: Buffer.from(`some text here`, 'utf-8')
+  }
 
-    transformContent(inputObj, options)
-    expect(parseToHTML).toHaveBeenCalledWith(expect.anything(), options)
-  })
+  transformContent(inputObj, options)
+  expect(parseToHTML).toHaveBeenCalledWith(expect.anything(), options)
 })

--- a/test/unit/transform-content-internals.test.js
+++ b/test/unit/transform-content-internals.test.js
@@ -3,7 +3,7 @@ const parseToHTML = require('../../src/markdown-to-html-parser')
 
 jest.mock('../../src/markdown-to-html-parser')
 
-const options = { contentTitle: 'Some Title' }
+const options = { contentTitle: 'Some Title', pathPath: 'some/base/path' }
 
 describe('Transformed content passed to html parser is of correct type', () => {
   it('Content passed into the html parser is a string', () => {
@@ -14,6 +14,18 @@ describe('Transformed content passed to html parser is of correct type', () => {
 
     transformContent(inputObj, options)
 
-    expect(parseToHTML).toHaveBeenCalledWith(expect.any(String))
+    expect(parseToHTML).toHaveBeenCalledWith(expect.any(String), expect.anything())
+  })
+})
+
+describe('', () => {
+  it('Passes the options to the html parser', () => {
+    const inputObj = {
+      relativePath: 'file-name.md',
+      raw: Buffer.from(`some text here`, 'utf-8')
+    }
+
+    transformContent(inputObj, options)
+    expect(parseToHTML).toHaveBeenCalledWith(expect.anything(), options)
   })
 })

--- a/test/unit/transform-content.test.js
+++ b/test/unit/transform-content.test.js
@@ -1,6 +1,9 @@
 const transformContent = require('../../src/transform-content.js')
 
-const options = { contentTitle: 'Some Title' }
+const options = {
+  contentTitle: 'Some Title',
+  basePath: '/morty-docs/some-repo'
+}
 
 describe('Transform-content returns correct relative path', () => {
   it('for the html made from .md', () => {
@@ -43,10 +46,10 @@ describe('Transform-content returns the correct html from markdown', () => {
     expect(result.raw).toMatchSnapshot()
   })
 
-  it('for Markdown with a title and a link', () => {
+  it('for Markdown with a title and links', () => {
     const inputObj = {
       relativePath: 'file-name.md',
-      raw: '# Title of simple-content.md \n[Link to MD in docs directory](docs/file-to-publish.md)'
+      raw: '# Title of simple-content.md \n[Relative link to MD in docs directory](docs/file-to-publish.md)\n[Root link to MD in docs directory](/docs/file-to-publish.md)'
     }
 
     const result = transformContent(inputObj, options)

--- a/test/unit/transform.test.js
+++ b/test/unit/transform.test.js
@@ -48,39 +48,19 @@ describe('transform.js', () => {
     expect(mockTransformContent).toHaveBeenCalledWith(mdObj, {})
   })
 
-  it('transforms .asciidoc files', () => {
-    const asciidocObj = {
-      relativePath: 'simple-content.asciidoc',
-      raw: '== Some AsciiDoc'
-    }
+  const asciidocExtensions = ['.asciidoc', '.adoc', '.asc']
 
-    const result = transform([asciidocObj], {})
+  asciidocExtensions.forEach(asciidocExtension => {
+    it(`transforms ${asciidocExtension} files`, () => {
+      const asciidocObj = {
+        relativePath: `simple-content${asciidocExtension}`,
+        raw: '== Some AsciiDoc'
+      }
 
-    expect(result).toEqual(expect.arrayContaining([mockTransformContentOutput]))
-    expect(mockTransformContent).toHaveBeenCalledWith(asciidocObj, {})
-  })
+      const result = transform([asciidocObj], {})
 
-  it('transforms .adoc files', () => {
-    const asciidocObj = {
-      relativePath: 'simple-content.adoc',
-      raw: '== Some AsciiDoc'
-    }
-
-    const result = transform([asciidocObj], {})
-
-    expect(result).toEqual(expect.arrayContaining([mockTransformContentOutput]))
-    expect(mockTransformContent).toHaveBeenCalledWith(asciidocObj, {})
-  })
-
-  it('transforms .asc files', () => {
-    const asciidocObj = {
-      relativePath: 'simple-content.asc',
-      raw: '== Some AsciiDoc'
-    }
-
-    const result = transform([asciidocObj], {})
-
-    expect(result).toEqual(expect.arrayContaining([mockTransformContentOutput]))
-    expect(mockTransformContent).toHaveBeenCalledWith(asciidocObj, {})
+      expect(result).toEqual(expect.arrayContaining([mockTransformContentOutput]))
+      expect(mockTransformContent).toHaveBeenCalledWith(asciidocObj, {})
+    })
   })
 })


### PR DESCRIPTION
🧐 What?

Add support for custom base paths to make markdown links starting with `/` to work correctly.
See issue #32 for details and an example.

🛠 How

- Add an optional `basePath` option.
- Add a `showdown` extension that adds the correct `basePath` to any markdown links that start with `/`.
- Small refactor to `transform-content.js` to pass the options to the markdown transformer but not the asciidoctor transformer.

🐞 Related issue

#32
