### PR TITLE
Fix index generation bug - nested directory indexes include items in parent with matching name

### DIFF
--- a/src/helpers/filter-files-in-dir.js
+++ b/src/helpers/filter-files-in-dir.js
@@ -4,18 +4,11 @@ function sortByDate (a, b) {
   return a.match(dateRegex) && b.match(dateRegex) ? b.localeCompare(a) : a.localeCompare(b)
 }
 
-function isFileInCurrentDir (filePath, directory) {
-  return (filePath.replace(directory, '').match(/\//g) || []).length <= 1
-}
-
-function filterFilesInDir (filePaths, directory) {
-  return filePaths.filter(filePath => {
-    return directory // directory = '' is falsy
-      ? filePath.startsWith(directory) && isFileInCurrentDir(filePath, directory)
-      : !filePath.includes('/') // returns true for files in root directory
-  })
-}
+const directoryDepth = path => path.split('/').length
+const isInRootDirectory = filePath => directoryDepth(filePath) === 1
+const isIn = directory => filePath => filePath.startsWith(directory) && ((directoryDepth(filePath) - 1) === directoryDepth(directory))
 
 module.exports = (filePaths, directory) => {
-  return filterFilesInDir(filePaths, directory).sort(sortByDate)
+  const isInSpecifiedDirectory = directory ? isIn(directory) : isInRootDirectory
+  return filePaths.filter(isInSpecifiedDirectory).sort(sortByDate)
 }

--- a/test/unit/helpers/filter-files-in-dir.test.js
+++ b/test/unit/helpers/filter-files-in-dir.test.js
@@ -5,6 +5,7 @@ describe('Filter files in directory', () => {
     const filePaths = [
       'File1.html',
       'File2.html',
+      'File2/ThisFileShouldBeExcluded.html',
       'SomeDir/File1.html',
       'SomeOtherDir/AnotherDir/File1.html'
     ]
@@ -24,8 +25,11 @@ describe('Filter files in directory', () => {
   it('returns files within a top level directory', () => {
     const filePaths = [
       'File1.html',
+      'SomeDir.html',
       'SomeDir/File1.html',
       'SomeDir/File2.html',
+      'SomeDir/File2/ThisFileShouldBeExcluded.html',
+      'SomeOtherDir/File1.html',
       'SomeOtherDir/AnotherDir/File1.html'
     ]
 
@@ -45,8 +49,11 @@ describe('Filter files in directory', () => {
     const filePaths = [
       'File1.html',
       'SomeDir/File1.html',
+      'SomeOtherDir/AnotherDir.html',
       'SomeOtherDir/AnotherDir/File1.html',
-      'SomeOtherDir/AnotherDir/File2.html'
+      'SomeOtherDir/AnotherDir/File2.html',
+      'SomeOtherDir/AnotherDir/File2/ThisFileShouldBeExcluded.html',
+      'SomeOtherDir/SomeAnotherDir/File1.html'
     ]
 
     const currentDirectory = 'SomeOtherDir/AnotherDir'


### PR DESCRIPTION
🧐 What?

Fixes the following bug in index page generation:

For a repo with files like
```bash
/A.md # filename "A.md" is "the same" as the "A" sub-directory
/A/B.md
/A/C.md
```

The generated `/A/index.html` page will incorrectly include a links for
```
/A/A.html # links to a file that does not exist
/A/B.html
/A/C.html
```

This should be
```
/A/B.html
/A/C.html
```


🛠 How

- Updates `filePaths` input for existing unit tests in `filter-files-in-dir.test.js` to exercise bug
- Updates `filter-files-in-dir.js` implementation to handle additional cases
