### PR TITLE
Encode filenames using encodeURIComponent to ensure usage of special characters

### DIFF
--- a/src/generate-indexes.js
+++ b/src/generate-indexes.js
@@ -16,7 +16,7 @@ const generateIndex = (htmlFilePaths, subDirPaths, contentTitle) => {
     const text = path.basename(filePath)
 
     return {
-      link: encodeURI(text),
+      link: encodeURIComponent(text),
       text,
       iconClass: 'fas fa-file-alt'
     }


### PR DESCRIPTION
🧐 What?

This fixes an issue where colons in filenames were being interpreted incorrectly in the browser

🛠 How

Switch from encodeURI to encodeURIComponent so all special characters are encoded. Because only relative paths are used this should not cause any issues.
