### PR TITLE
Header breadcrumbs rework

### DIFF
--- a/run.js
+++ b/run.js
@@ -7,12 +7,13 @@ const directoryToConvert = JSON.parse(process.env.npm_config_argv).remain[0] || 
 const resolvedPath = path.resolve(directoryToConvert)
 
 const mortyDocs = async () => {
+  const basePath = 'morty-docs/some-repo'
   const inputObjs = await generateTransformInput(resolvedPath)
 
-  const files = transform(inputObjs, { contentTitle: 'some-repo', basePath: 'morty-docs/some-repo' })
+  const files = transform(inputObjs, { contentTitle: 'some-repo', basePath })
 
   files.forEach(file => {
-    let filePath = `www/${file.relativePath}`
+    let filePath = `www/${basePath}/${file.relativePath}`
     fsExtra.ensureFileSync(filePath)
     fsExtra.writeFileSync(filePath, file.raw)
   })

--- a/src/generate-indexes.js
+++ b/src/generate-indexes.js
@@ -4,7 +4,7 @@ const getDirectories = require('./helpers/get-directory-paths')
 const filterFilesInDirectory = require('./helpers/filter-files-in-dir')
 const filterDirectoriesInDirectory = require('./helpers/filter-dirs-in-dir')
 
-const generateIndex = (htmlFilePaths, subDirPaths, options) => {
+const generateIndex = (directory, htmlFilePaths, subDirPaths, options) => {
   const subDirLinks = subDirPaths.filter(dirPath => !dirPath.includes('/')).map(dirPath => ({
     link: `${dirPath}/index.html`,
     text: dirPath,
@@ -21,7 +21,7 @@ const generateIndex = (htmlFilePaths, subDirPaths, options) => {
     }
   })
 
-  return renderIndexPage([...subDirLinks, ...fileLinks], options, htmlFilePaths[0])
+  return renderIndexPage([...subDirLinks, ...fileLinks], options, directory)
 }
 
 const generateIndexes = (files, options = { contentTitle: '' }) => {
@@ -30,7 +30,6 @@ const generateIndexes = (files, options = { contentTitle: '' }) => {
     .filter(relativePath => path.extname(relativePath) === '.html')
 
   const directories = getDirectories(htmlFilePaths)
-
   // If we have not got a 'root' folder, then add one.
   // TODO: Refactor this so it is not needed (maybe?)
   if (!directories.includes('')) {
@@ -44,7 +43,7 @@ const generateIndexes = (files, options = { contentTitle: '' }) => {
 
     return {
       relativePath: indexPath,
-      raw: Buffer.from(generateIndex(filesInDir, subDirsInDir, options))
+      raw: Buffer.from(generateIndex(directory, filesInDir, subDirsInDir, options))
     }
   })
 

--- a/src/helpers/get-header-paths.js
+++ b/src/helpers/get-header-paths.js
@@ -1,9 +1,18 @@
-const getHeaderLinks = (relPath) => {
-  return (relPath || '')
-    .split('/')
-    .filter(part => !part || !part.includes('.'))
-    .map((part, index, array) => array.slice(0, index + 1))
-    .map(parts => parts.join('/'))
+const getHeaderLinks = (basePath, relPath = '') => {
+  const combinedParts = [...basePath.split('/'), ...relPath.split('/')]
+  const paths = combinedParts.filter(part => part && !part.endsWith('.html'))
+
+  return paths.reduce((acc, item, index) => {
+    const prevPart = acc[index - 1]
+    const path = prevPart ? `${prevPart.path}/${item}` : `/${item}`
+
+    acc.push({
+      text: item,
+      path
+    })
+
+    return acc
+  }, [])
 }
 
 module.exports = getHeaderLinks

--- a/src/helpers/get-header-paths.js
+++ b/src/helpers/get-header-paths.js
@@ -1,6 +1,6 @@
 const getHeaderLinks = (basePath, relPath = '') => {
   const combinedParts = [...basePath.split('/'), ...relPath.split('/')]
-  const paths = combinedParts.filter(part => part && !part.endsWith('.html'))
+  const paths = combinedParts.filter(part => part && (!part.endsWith('.html') && !part.endsWith('.md')))
 
   return paths.reduce((acc, item, index) => {
     const prevPart = acc[index - 1]

--- a/src/page-renderers/Components/Header.jsx
+++ b/src/page-renderers/Components/Header.jsx
@@ -9,41 +9,43 @@ const Styles = {
     height: '60px',
     marginBottom: '0',
     width: '100%',
-    paddingRight: '5px',
-    paddingLeft: '5px'
+    padding: '1.142rem'
+  },
+  headerNav: {
   },
   headerLinks: {
-    marginTop: '5px'
+    padding: '0',
+    listStyle: 'none',
+    display: 'flex',
+    height: '100%',
+    alignItems: 'center'
+  },
+  headerLink: {
+    textAlign: 'left',
+    color: 'lightblue',
+    fontSize: '2rem'
+  },
+  separator: {
+    margin: '0 0.28rem',
+    color: '#ebebeb'
   }
 }
 
-const Header = ({ relPath, basePath }) => {
-  let pathParts
-  let headerPaths
-  let headerLinks
+const HeaderLinks = ({ paths }) => paths.map(({ text, path }, index) => {
+  return <li>
+    { index !== paths.length ? <span aria-hidden style={Styles.separator}>/</span> : undefined }
+    <a style={Styles.headerLink} href={path} key={index}>{text}</a>
+  </li>
+})
 
-  if (relPath) {
-    pathParts = relPath.split('/')
-    headerPaths = getHeaderPaths(relPath)
-
-    const base = basePath ? '/' + basePath : ''
-
-    headerLinks = headerPaths.map((dir, index) => {
-      return <a style={{ textAlign: 'left', paddingRight: '3px', color: '#4f8df0', fontSize: '20' }} href={base + '/' + dir} key={index}><span>{'/' + pathParts[index]}</span></a>
-    })
-  } else {
-    headerLinks = <h3 style={{ color: '#fff', marginTop: '5px' }}>Morty-Docs</h3>
-  }
-
-  return (
-    <div className='container' style={Styles.navbar}>
-      <div className='row col-md-12' style={{ width: '100%', paddingTop: '10px', paddingRight: '0px', paddingLeft: '25px' }}>
-        <div className='col-md-4' style={Styles.headerLinks}>
-          {headerLinks}
-        </div>
-      </div>
-    </div>
-  )
-}
+const Header = ({ relPath, basePath }) => (
+  <div className='container' style={Styles.navbar}>
+    <nav style={Styles.headerNav}>
+      <ol style={Styles.headerLinks}>
+        <HeaderLinks paths={getHeaderPaths(basePath, relPath)} />
+      </ol>
+    </nav>
+  </div>
+)
 
 module.exports = Header

--- a/src/page-renderers/Components/Header.jsx
+++ b/src/page-renderers/Components/Header.jsx
@@ -32,9 +32,9 @@ const Styles = {
 }
 
 const HeaderLinks = ({ paths }) => paths.map(({ text, path }, index) => {
-  return <li>
+  return <li key={index}>
     { index !== paths.length ? <span aria-hidden style={Styles.separator}>/</span> : undefined }
-    <a style={Styles.headerLink} href={path} key={index}>{text}</a>
+    <a style={Styles.headerLink} href={path}>{text}</a>
   </li>
 })
 

--- a/test/unit/__snapshots__/generate-indexes.test.js.snap
+++ b/test/unit/__snapshots__/generate-indexes.test.js.snap
@@ -310,6 +310,18 @@ exports[`Generate Indexes with the correct html The correct links are included i
                 some-repo
               </a>
             </li>
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs/some-repo/docs"
+              >
+                docs
+              </a>
+            </li>
           </ol>
         </nav>
       </div>

--- a/test/unit/__snapshots__/generate-indexes.test.js.snap
+++ b/test/unit/__snapshots__/generate-indexes.test.js.snap
@@ -30,16 +30,36 @@ exports[`Generate Indexes with the correct html The correct links are included i
   <body style="min-height:100vh">
     <div style="min-height:75vh;padding-bottom:20px">
       <div class="container"
-           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding-right:5px;padding-left:5px"
+           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding:1.142rem"
       >
-        <div class="row col-md-12"
-             style="width:100%;padding-top:10px;padding-right:0px;padding-left:25px"
-        >
-          <div class="col-md-4"
-               style="margin-top:5px"
-          >
-          </div>
-        </div>
+        <nav>
+          <ol style="padding:0;list-style:none;display:flex;height:100%;align-items:center">
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs"
+              >
+                morty-docs
+              </a>
+            </li>
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs/some-repo"
+              >
+                some-repo
+              </a>
+            </li>
+          </ol>
+        </nav>
       </div>
       <div class="container"
            style="margin-top:10px"
@@ -141,23 +161,48 @@ exports[`Generate Indexes with the correct html The correct links are included i
   <body style="min-height:100vh">
     <div style="min-height:75vh;padding-bottom:20px">
       <div class="container"
-           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding-right:5px;padding-left:5px"
+           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding:1.142rem"
       >
-        <div class="row col-md-12"
-             style="width:100%;padding-top:10px;padding-right:0px;padding-left:25px"
-        >
-          <div class="col-md-4"
-               style="margin-top:5px"
-          >
-            <a style="text-align:left;padding-right:3px;color:#4f8df0;font-size:20"
-               href="/folder"
-            >
-              <span>
-                /folder
+        <nav>
+          <ol style="padding:0;list-style:none;display:flex;height:100%;align-items:center">
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
               </span>
-            </a>
-          </div>
-        </div>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs"
+              >
+                morty-docs
+              </a>
+            </li>
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs/some-repo"
+              >
+                some-repo
+              </a>
+            </li>
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs/some-repo/folder"
+              >
+                folder
+              </a>
+            </li>
+          </ol>
+        </nav>
       </div>
       <div class="container"
            style="margin-top:10px"
@@ -237,19 +282,36 @@ exports[`Generate Indexes with the correct html The correct links are included i
   <body style="min-height:100vh">
     <div style="min-height:75vh;padding-bottom:20px">
       <div class="container"
-           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding-right:5px;padding-left:5px"
+           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding:1.142rem"
       >
-        <div class="row col-md-12"
-             style="width:100%;padding-top:10px;padding-right:0px;padding-left:25px"
-        >
-          <div class="col-md-4"
-               style="margin-top:5px"
-          >
-            <h3 style="color:#fff;margin-top:5px">
-              Morty-Docs
-            </h3>
-          </div>
-        </div>
+        <nav>
+          <ol style="padding:0;list-style:none;display:flex;height:100%;align-items:center">
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs"
+              >
+                morty-docs
+              </a>
+            </li>
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs/some-repo"
+              >
+                some-repo
+              </a>
+            </li>
+          </ol>
+        </nav>
       </div>
       <div class="container"
            style="margin-top:10px"
@@ -329,30 +391,60 @@ exports[`Generate Indexes with the correct html The correct links are included i
   <body style="min-height:100vh">
     <div style="min-height:75vh;padding-bottom:20px">
       <div class="container"
-           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding-right:5px;padding-left:5px"
+           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding:1.142rem"
       >
-        <div class="row col-md-12"
-             style="width:100%;padding-top:10px;padding-right:0px;padding-left:25px"
-        >
-          <div class="col-md-4"
-               style="margin-top:5px"
-          >
-            <a style="text-align:left;padding-right:3px;color:#4f8df0;font-size:20"
-               href="/docs"
-            >
-              <span>
-                /docs
+        <nav>
+          <ol style="padding:0;list-style:none;display:flex;height:100%;align-items:center">
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
               </span>
-            </a>
-            <a style="text-align:left;padding-right:3px;color:#4f8df0;font-size:20"
-               href="/docs/arch"
-            >
-              <span>
-                /arch
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs"
+              >
+                morty-docs
+              </a>
+            </li>
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
               </span>
-            </a>
-          </div>
-        </div>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs/some-repo"
+              >
+                some-repo
+              </a>
+            </li>
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs/some-repo/docs"
+              >
+                docs
+              </a>
+            </li>
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs/some-repo/docs/arch"
+              >
+                arch
+              </a>
+            </li>
+          </ol>
+        </nav>
       </div>
       <div class="container"
            style="margin-top:10px"
@@ -432,16 +524,36 @@ exports[`Generate Indexes with the correct html to match snapshot with a colon i
   <body style="min-height:100vh">
     <div style="min-height:75vh;padding-bottom:20px">
       <div class="container"
-           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding-right:5px;padding-left:5px"
+           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding:1.142rem"
       >
-        <div class="row col-md-12"
-             style="width:100%;padding-top:10px;padding-right:0px;padding-left:25px"
-        >
-          <div class="col-md-4"
-               style="margin-top:5px"
-          >
-          </div>
-        </div>
+        <nav>
+          <ol style="padding:0;list-style:none;display:flex;height:100%;align-items:center">
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs"
+              >
+                morty-docs
+              </a>
+            </li>
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs/some-repo"
+              >
+                some-repo
+              </a>
+            </li>
+          </ol>
+        </nav>
       </div>
       <div class="container"
            style="margin-top:10px"
@@ -532,16 +644,36 @@ exports[`Generate Indexes with the correct html to match snapshot with a content
   <body style="min-height:100vh">
     <div style="min-height:75vh;padding-bottom:20px">
       <div class="container"
-           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding-right:5px;padding-left:5px"
+           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding:1.142rem"
       >
-        <div class="row col-md-12"
-             style="width:100%;padding-top:10px;padding-right:0px;padding-left:25px"
-        >
-          <div class="col-md-4"
-               style="margin-top:5px"
-          >
-          </div>
-        </div>
+        <nav>
+          <ol style="padding:0;list-style:none;display:flex;height:100%;align-items:center">
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs"
+              >
+                morty-docs
+              </a>
+            </li>
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs/some-repo"
+              >
+                some-repo
+              </a>
+            </li>
+          </ol>
+        </nav>
       </div>
       <div class="container"
            style="margin-top:10px"
@@ -639,16 +771,36 @@ exports[`Generate Indexes with the correct html to match snapshot without a cont
   <body style="min-height:100vh">
     <div style="min-height:75vh;padding-bottom:20px">
       <div class="container"
-           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding-right:5px;padding-left:5px"
+           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding:1.142rem"
       >
-        <div class="row col-md-12"
-             style="width:100%;padding-top:10px;padding-right:0px;padding-left:25px"
-        >
-          <div class="col-md-4"
-               style="margin-top:5px"
-          >
-          </div>
-        </div>
+        <nav>
+          <ol style="padding:0;list-style:none;display:flex;height:100%;align-items:center">
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs"
+              >
+                morty-docs
+              </a>
+            </li>
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs/some-repo"
+              >
+                some-repo
+              </a>
+            </li>
+          </ol>
+        </nav>
       </div>
       <div class="container"
            style="margin-top:10px"

--- a/test/unit/__snapshots__/header-links-snapshot.test.js.snap
+++ b/test/unit/__snapshots__/header-links-snapshot.test.js.snap
@@ -10,63 +10,77 @@ exports[`The header is rendered with the correct breadcrumb links  When a basepa
       "borderRadius": "0",
       "height": "60px",
       "marginBottom": "0",
-      "paddingLeft": "5px",
-      "paddingRight": "5px",
+      "padding": "1.142rem",
       "width": "100%",
     }
   }
 >
-  <div
-    className="row col-md-12"
-    style={
-      Object {
-        "paddingLeft": "25px",
-        "paddingRight": "0px",
-        "paddingTop": "10px",
-        "width": "100%",
-      }
-    }
+  <nav
+    style={Object {}}
   >
-    <div
-      className="col-md-4"
+    <ol
       style={
         Object {
-          "marginTop": "5px",
+          "alignItems": "center",
+          "display": "flex",
+          "height": "100%",
+          "listStyle": "none",
+          "padding": "0",
         }
       }
     >
-      <a
-        href="/folder"
-        style={
-          Object {
-            "color": "#4f8df0",
-            "fontSize": "20",
-            "paddingRight": "3px",
-            "textAlign": "left",
+      <li>
+        <span
+          aria-hidden={true}
+          style={
+            Object {
+              "color": "#ebebeb",
+              "margin": "0 0.28rem",
+            }
           }
-        }
-      >
-        <span>
-          /folder
+        >
+          /
         </span>
-      </a>
-      <a
-        href="/folder/nestedFolder"
-        style={
-          Object {
-            "color": "#4f8df0",
-            "fontSize": "20",
-            "paddingRight": "3px",
-            "textAlign": "left",
+        <a
+          href="/folder"
+          style={
+            Object {
+              "color": "lightblue",
+              "fontSize": "2rem",
+              "textAlign": "left",
+            }
           }
-        }
-      >
-        <span>
-          /nestedFolder
+        >
+          folder
+        </a>
+      </li>
+      <li>
+        <span
+          aria-hidden={true}
+          style={
+            Object {
+              "color": "#ebebeb",
+              "margin": "0 0.28rem",
+            }
+          }
+        >
+          /
         </span>
-      </a>
-    </div>
-  </div>
+        <a
+          href="/folder/nestedFolder"
+          style={
+            Object {
+              "color": "lightblue",
+              "fontSize": "2rem",
+              "textAlign": "left",
+            }
+          }
+        >
+          nestedFolder
+        </a>
+      </li>
+    </ol>
+  </nav>
 </div>
 `;
 
@@ -80,62 +94,126 @@ exports[`The header is rendered with the correct breadcrumb links  When a basepa
       "borderRadius": "0",
       "height": "60px",
       "marginBottom": "0",
-      "paddingLeft": "5px",
-      "paddingRight": "5px",
+      "padding": "1.142rem",
       "width": "100%",
     }
   }
 >
-  <div
-    className="row col-md-12"
-    style={
-      Object {
-        "paddingLeft": "25px",
-        "paddingRight": "0px",
-        "paddingTop": "10px",
-        "width": "100%",
-      }
-    }
+  <nav
+    style={Object {}}
   >
-    <div
-      className="col-md-4"
+    <ol
       style={
         Object {
-          "marginTop": "5px",
+          "alignItems": "center",
+          "display": "flex",
+          "height": "100%",
+          "listStyle": "none",
+          "padding": "0",
         }
       }
     >
-      <a
-        href="/morty-docs/some-repo/folder"
-        style={
-          Object {
-            "color": "#4f8df0",
-            "fontSize": "20",
-            "paddingRight": "3px",
-            "textAlign": "left",
+      <li>
+        <span
+          aria-hidden={true}
+          style={
+            Object {
+              "color": "#ebebeb",
+              "margin": "0 0.28rem",
+            }
           }
-        }
-      >
-        <span>
-          /folder
+        >
+          /
         </span>
-      </a>
-      <a
-        href="/morty-docs/some-repo/folder/nestedFolder"
-        style={
-          Object {
-            "color": "#4f8df0",
-            "fontSize": "20",
-            "paddingRight": "3px",
-            "textAlign": "left",
+        <a
+          href="/morty-docs"
+          style={
+            Object {
+              "color": "lightblue",
+              "fontSize": "2rem",
+              "textAlign": "left",
+            }
           }
-        }
-      >
-        <span>
-          /nestedFolder
+        >
+          morty-docs
+        </a>
+      </li>
+      <li>
+        <span
+          aria-hidden={true}
+          style={
+            Object {
+              "color": "#ebebeb",
+              "margin": "0 0.28rem",
+            }
+          }
+        >
+          /
         </span>
-      </a>
-    </div>
-  </div>
+        <a
+          href="/morty-docs/some-repo"
+          style={
+            Object {
+              "color": "lightblue",
+              "fontSize": "2rem",
+              "textAlign": "left",
+            }
+          }
+        >
+          some-repo
+        </a>
+      </li>
+      <li>
+        <span
+          aria-hidden={true}
+          style={
+            Object {
+              "color": "#ebebeb",
+              "margin": "0 0.28rem",
+            }
+          }
+        >
+          /
+        </span>
+        <a
+          href="/morty-docs/some-repo/folder"
+          style={
+            Object {
+              "color": "lightblue",
+              "fontSize": "2rem",
+              "textAlign": "left",
+            }
+          }
+        >
+          folder
+        </a>
+      </li>
+      <li>
+        <span
+          aria-hidden={true}
+          style={
+            Object {
+              "color": "#ebebeb",
+              "margin": "0 0.28rem",
+            }
+          }
+        >
+          /
+        </span>
+        <a
+          href="/morty-docs/some-repo/folder/nestedFolder"
+          style={
+            Object {
+              "color": "lightblue",
+              "fontSize": "2rem",
+              "textAlign": "left",
+            }
+          }
+        >
+          nestedFolder
+        </a>
+      </li>
+    </ol>
+  </nav>
 </div>
 `;

--- a/test/unit/__snapshots__/transform-content.test.js.snap
+++ b/test/unit/__snapshots__/transform-content.test.js.snap
@@ -25,16 +25,48 @@ exports[`Transform-content returns the correct html from AsciiDoc for .adoc with
   <body style="min-height:100vh">
     <div style="min-height:75vh;padding-bottom:20px">
       <div class="container"
-           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding-right:5px;padding-left:5px"
+           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding:1.142rem"
       >
-        <div class="row col-md-12"
-             style="width:100%;padding-top:10px;padding-right:0px;padding-left:25px"
-        >
-          <div class="col-md-4"
-               style="margin-top:5px"
-          >
-          </div>
-        </div>
+        <nav>
+          <ol style="padding:0;list-style:none;display:flex;height:100%;align-items:center">
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs"
+              >
+                morty-docs
+              </a>
+            </li>
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs/some-repo"
+              >
+                some-repo
+              </a>
+            </li>
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs/some-repo/file-name.adoc"
+              >
+                file-name.adoc
+              </a>
+            </li>
+          </ol>
+        </nav>
       </div>
       <div class="container">
         <div class="sect1">
@@ -106,16 +138,48 @@ exports[`Transform-content returns the correct html from AsciiDoc for .asc with 
   <body style="min-height:100vh">
     <div style="min-height:75vh;padding-bottom:20px">
       <div class="container"
-           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding-right:5px;padding-left:5px"
+           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding:1.142rem"
       >
-        <div class="row col-md-12"
-             style="width:100%;padding-top:10px;padding-right:0px;padding-left:25px"
-        >
-          <div class="col-md-4"
-               style="margin-top:5px"
-          >
-          </div>
-        </div>
+        <nav>
+          <ol style="padding:0;list-style:none;display:flex;height:100%;align-items:center">
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs"
+              >
+                morty-docs
+              </a>
+            </li>
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs/some-repo"
+              >
+                some-repo
+              </a>
+            </li>
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs/some-repo/file-name.asc"
+              >
+                file-name.asc
+              </a>
+            </li>
+          </ol>
+        </nav>
       </div>
       <div class="container">
         <div class="sect1">
@@ -187,16 +251,48 @@ exports[`Transform-content returns the correct html from AsciiDoc for .asciidoc 
   <body style="min-height:100vh">
     <div style="min-height:75vh;padding-bottom:20px">
       <div class="container"
-           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding-right:5px;padding-left:5px"
+           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding:1.142rem"
       >
-        <div class="row col-md-12"
-             style="width:100%;padding-top:10px;padding-right:0px;padding-left:25px"
-        >
-          <div class="col-md-4"
-               style="margin-top:5px"
-          >
-          </div>
-        </div>
+        <nav>
+          <ol style="padding:0;list-style:none;display:flex;height:100%;align-items:center">
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs"
+              >
+                morty-docs
+              </a>
+            </li>
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs/some-repo"
+              >
+                some-repo
+              </a>
+            </li>
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs/some-repo/file-name.asciidoc"
+              >
+                file-name.asciidoc
+              </a>
+            </li>
+          </ol>
+        </nav>
       </div>
       <div class="container">
         <div class="sect1">
@@ -268,16 +364,48 @@ exports[`Transform-content returns the correct html from AsciiDoc for a line of 
   <body style="min-height:100vh">
     <div style="min-height:75vh;padding-bottom:20px">
       <div class="container"
-           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding-right:5px;padding-left:5px"
+           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding:1.142rem"
       >
-        <div class="row col-md-12"
-             style="width:100%;padding-top:10px;padding-right:0px;padding-left:25px"
-        >
-          <div class="col-md-4"
-               style="margin-top:5px"
-          >
-          </div>
-        </div>
+        <nav>
+          <ol style="padding:0;list-style:none;display:flex;height:100%;align-items:center">
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs"
+              >
+                morty-docs
+              </a>
+            </li>
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs/some-repo"
+              >
+                some-repo
+              </a>
+            </li>
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs/some-repo/file-name.asciidoc"
+              >
+                file-name.asciidoc
+              </a>
+            </li>
+          </ol>
+        </nav>
       </div>
       <div class="container">
         <div class="paragraph">
@@ -340,16 +468,36 @@ exports[`Transform-content returns the correct html from markdown for Markdown w
   <body style="min-height:100vh">
     <div style="min-height:75vh;padding-bottom:20px">
       <div class="container"
-           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding-right:5px;padding-left:5px"
+           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding:1.142rem"
       >
-        <div class="row col-md-12"
-             style="width:100%;padding-top:10px;padding-right:0px;padding-left:25px"
-        >
-          <div class="col-md-4"
-               style="margin-top:5px"
-          >
-          </div>
-        </div>
+        <nav>
+          <ol style="padding:0;list-style:none;display:flex;height:100%;align-items:center">
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs"
+              >
+                morty-docs
+              </a>
+            </li>
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs/some-repo"
+              >
+                some-repo
+              </a>
+            </li>
+          </ol>
+        </nav>
       </div>
       <div class="container">
         <h1 id="title-of-simple-contentmd">
@@ -421,16 +569,36 @@ exports[`Transform-content returns the correct html from markdown for a line of 
   <body style="min-height:100vh">
     <div style="min-height:75vh;padding-bottom:20px">
       <div class="container"
-           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding-right:5px;padding-left:5px"
+           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding:1.142rem"
       >
-        <div class="row col-md-12"
-             style="width:100%;padding-top:10px;padding-right:0px;padding-left:25px"
-        >
-          <div class="col-md-4"
-               style="margin-top:5px"
-          >
-          </div>
-        </div>
+        <nav>
+          <ol style="padding:0;list-style:none;display:flex;height:100%;align-items:center">
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs"
+              >
+                morty-docs
+              </a>
+            </li>
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs/some-repo"
+              >
+                some-repo
+              </a>
+            </li>
+          </ol>
+        </nav>
       </div>
       <div class="container">
         <p>

--- a/test/unit/generate-indexes.test.js
+++ b/test/unit/generate-indexes.test.js
@@ -6,7 +6,7 @@ describe('Generating indexes', () => {
       relativePath: 'someRootFile.html'
     }]
 
-    const actual = generateIndexes(input, { repoName: 'some-repo' })
+    const actual = generateIndexes(input, { repoName: 'some-repo', basePath: 'morty-docs/some-repo' })
     const expected = [{
       relativePath: 'index.html',
       raw: expect.any(Buffer)
@@ -21,7 +21,7 @@ describe('Generating indexes', () => {
       relativePath: 'rfc/someRfc.html'
     }]
 
-    const actual = generateIndexes(input, { repoName: 'some-repo' })
+    const actual = generateIndexes(input, { repoName: 'some-repo', basePath: 'morty-docs/some-repo' })
 
     const expected = [{
       relativePath: 'index.html',
@@ -44,7 +44,7 @@ describe('Generating indexes', () => {
       relativePath: 'someOtherFolder/file.html'
     }]
 
-    const actual = generateIndexes(input, { repoName: 'some-repo' })
+    const actual = generateIndexes(input, { repoName: 'some-repo', basePath: 'morty-docs/some-repo' })
     const expected = [{
       relativePath: 'index.html',
       raw: expect.any(Buffer)
@@ -65,7 +65,7 @@ describe('Generating indexes', () => {
       relativePath: 'docs/arch/someMDFile.html'
     }]
 
-    const actual = generateIndexes(input, { repoName: 'some-repo' })
+    const actual = generateIndexes(input, { repoName: 'some-repo', basePath: 'morty-docs/some-repo' })
 
     const expected = [{
       relativePath: 'index.html',
@@ -93,7 +93,7 @@ describe('Generate Indexes with the correct html', () => {
       relativePath: 'docs/arch/furtherNestedFile.html'
     }]
 
-    const actual = generateIndexes(input, { repoName: 'some-repo' })
+    const actual = generateIndexes(input, { repoName: 'some-repo', basePath: 'morty-docs/some-repo' })
 
     expect(actual[0].raw.toString()).toMatchSnapshot()
     expect(actual[1].raw.toString()).toMatchSnapshot()
@@ -108,7 +108,7 @@ describe('Generate Indexes with the correct html', () => {
       relativePath: 'foo2.html'
     }]
 
-    const actual = generateIndexes(input, { contentTitle: 'some-repo' })
+    const actual = generateIndexes(input, { contentTitle: 'some-repo', basePath: 'morty-docs/some-repo' })
 
     expect(actual[0].raw.toString()).toMatchSnapshot()
   })
@@ -120,7 +120,7 @@ describe('Generate Indexes with the correct html', () => {
       relativePath: 'foo2.html'
     }]
 
-    const actual = generateIndexes(input, { })
+    const actual = generateIndexes(input, { basePath: 'morty-docs/some-repo' })
 
     expect(actual[0].raw.toString()).toMatchSnapshot()
   })
@@ -132,7 +132,7 @@ describe('Generate Indexes with the correct html', () => {
       relativePath: 'foo2.html'
     }]
 
-    const actual = generateIndexes(input, { })
+    const actual = generateIndexes(input, { basePath: 'morty-docs/some-repo' })
 
     expect(actual[0].raw.toString()).toMatchSnapshot()
   })

--- a/test/unit/helpers/get-header-paths.test.js
+++ b/test/unit/helpers/get-header-paths.test.js
@@ -3,7 +3,7 @@ const getHeaderPaths = require('../../../src/helpers/get-header-paths')
 describe('Get header paths', () => {
   it('returns an array of every possible path', () => {
     const basePath = 'morty-docs/some-repo'
-    const relPath = 'folder/subFolder/nestedSubFolder/file.md'
+    const relPath = 'folder/subFolder/nestedSubFolder/file.html'
     const expected = [
       {
         text: 'morty-docs',
@@ -50,11 +50,19 @@ describe('Get header paths', () => {
     expect(actual).toEqual(expected)
   })
 
-  it('filters out any .html files', () => {
+  it('filters out any .html', () => {
     const basePath = 'morty-docs/some-repo'
     const relPath = 'folder/subFolder/nestedSubFolder/file.html'
     const headerLinks = getHeaderPaths(basePath, relPath)
 
     expect(headerLinks).toEqual(expect.not.arrayContaining(['file.html']))
+  })
+
+  it('filters out any .md', () => {
+    const basePath = 'morty-docs/some-repo'
+    const relPath = 'folder/subFolder/nestedSubFolder/file.md'
+    const headerLinks = getHeaderPaths(basePath, relPath)
+
+    expect(headerLinks).toEqual(expect.not.arrayContaining(['file.md']))
   })
 })

--- a/test/unit/helpers/get-header-paths.test.js
+++ b/test/unit/helpers/get-header-paths.test.js
@@ -1,24 +1,60 @@
 const getHeaderPaths = require('../../../src/helpers/get-header-paths')
 
-describe('When passed a relative path', () => {
-  const relPath = 'folder/subFolder/nestedSubFolder/file.md'
-  const pathParts = relPath.split('/')
-
+describe('Get header paths', () => {
   it('returns an array of every possible path', () => {
+    const basePath = 'morty-docs/some-repo'
+    const relPath = 'folder/subFolder/nestedSubFolder/file.md'
     const expected = [
-      'folder',
-      'folder/subFolder',
-      'folder/subFolder/nestedSubFolder'
+      {
+        text: 'morty-docs',
+        path: '/morty-docs'
+      },
+      {
+        text: 'some-repo',
+        path: '/morty-docs/some-repo'
+      },
+      {
+        text: 'folder',
+        path: '/morty-docs/some-repo/folder'
+      },
+      {
+        text: 'subFolder',
+        path: '/morty-docs/some-repo/folder/subFolder'
+      },
+      {
+        text: 'nestedSubFolder',
+        path: '/morty-docs/some-repo/folder/subFolder/nestedSubFolder'
+      }
     ]
 
-    const actual = getHeaderPaths(relPath, pathParts)
+    const actual = getHeaderPaths(basePath, relPath)
 
     expect(actual).toEqual(expected)
   })
 
-  it('filters out any .md files', () => {
-    const headerLinks = getHeaderPaths(relPath, pathParts)
+  it('handles a missing relPath', () => {
+    const basePath = 'morty-docs/some-repo'
+    const expected = [
+      {
+        text: 'morty-docs',
+        path: '/morty-docs'
+      },
+      {
+        text: 'some-repo',
+        path: '/morty-docs/some-repo'
+      }
+    ]
 
-    expect(headerLinks).toEqual(expect.not.arrayContaining(['file.md']))
+    const actual = getHeaderPaths(basePath)
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('filters out any .html files', () => {
+    const basePath = 'morty-docs/some-repo'
+    const relPath = 'folder/subFolder/nestedSubFolder/file.html'
+    const headerLinks = getHeaderPaths(basePath, relPath)
+
+    expect(headerLinks).toEqual(expect.not.arrayContaining(['file.html']))
   })
 })

--- a/test/unit/transform-content-internals.test.js
+++ b/test/unit/transform-content-internals.test.js
@@ -3,7 +3,7 @@ const parseToHTML = require('../../src/markdown-to-html-parser')
 
 jest.mock('../../src/markdown-to-html-parser')
 
-const options = { contentTitle: 'Some Title', pathPath: 'some/base/path' }
+const options = { contentTitle: 'Some Title', basePath: 'some/base/path' }
 
 describe('Transformed content passed to html parser is of correct type', () => {
   it('Content passed into the html parser is a string', () => {

--- a/test/unit/transform.test.js
+++ b/test/unit/transform.test.js
@@ -11,7 +11,7 @@ describe('transform.js', () => {
       raw: 'Input-Raw-for-simple-content.PNG'
     }
 
-    const result = transform([notMdObj])
+    const result = transform([notMdObj], { basePath: 'morty-docs/some-repo' })
 
     expect(result).toEqual(expect.arrayContaining([notMdObj]))
   })
@@ -42,10 +42,10 @@ describe('transform.js', () => {
       raw: '# Some Markdown'
     }
 
-    const result = transform([mdObj], {})
+    const result = transform([mdObj], { basePath: 'morty-docs/some-repo' })
 
     expect(result).toEqual(expect.arrayContaining([mockTransformContentOutput]))
-    expect(mockTransformContent).toHaveBeenCalledWith(mdObj, {})
+    expect(mockTransformContent).toHaveBeenCalledWith(mdObj, { basePath: 'morty-docs/some-repo' })
   })
 
   const asciidocExtensions = ['.asciidoc', '.adoc', '.asc']
@@ -57,10 +57,10 @@ describe('transform.js', () => {
         raw: '== Some AsciiDoc'
       }
 
-      const result = transform([asciidocObj], {})
+      const result = transform([asciidocObj], { basePath: 'morty-docs/some-repo' })
 
       expect(result).toEqual(expect.arrayContaining([mockTransformContentOutput]))
-      expect(mockTransformContent).toHaveBeenCalledWith(asciidocObj, {})
+      expect(mockTransformContent).toHaveBeenCalledWith(asciidocObj, { basePath: 'morty-docs/some-repo' })
     })
   })
 })


### PR DESCRIPTION
🧐 What?

Fixing the recently added header breadcrumb nav. We were missing off the root folder but I have also added the top-level directory as well to go back to the homepage.

Also, took the opportunity to add some A11y fixes, sort of some of the styles, etc.

🛠 How

Reworking the way we build up the links to render. 

👀 See

![image](https://user-images.githubusercontent.com/1648177/97712307-2ad67580-1ab6-11eb-878d-be0aff1db22e.png)
