### PR TITLE
Publish to npm only on v*.*.* tags

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,7 +3,7 @@ name: Node.js Package
 on:
   push:
     tags:
-      - '*'
+      - v*.*.*
 
 jobs:
   build:


### PR DESCRIPTION
🧐 What?

<!--[Enter a brief description of what this pull request does] -->
This will ensure that the npm publish will only happen for tags that match "v*.*.*"

🛠 How

<!-- [How does this PR perform the features described in What, keep technical detail brief and/or high level - more detail can be requested in comments] -->
It changes the "on.push.tags" from "*" to "v*.*.*"

👀 See <!--[optional]-->

<!--[Describe or add screenshots]-->

🐞 Related issue <!--[optional]-->

<!--[Link to issue]-->
