### PR TITLE
Host raw PDFs

### DIFF
--- a/src/generate-indexes.js
+++ b/src/generate-indexes.js
@@ -4,14 +4,14 @@ const getDirectories = require('./helpers/get-directory-paths')
 const filterFilesInDirectory = require('./helpers/filter-files-in-dir')
 const filterDirectoriesInDirectory = require('./helpers/filter-dirs-in-dir')
 
-const generateIndex = (directory, htmlFilePaths, subDirPaths, options) => {
+const generateIndex = (directory, filePaths, subDirPaths, options) => {
   const subDirLinks = subDirPaths.filter(dirPath => !dirPath.includes('/')).map(dirPath => ({
     link: `${dirPath}/index.html`,
     text: dirPath,
     iconClass: 'fas fa-folder-open'
   }))
 
-  const fileLinks = htmlFilePaths.map(filePath => {
+  const fileLinks = filePaths.map(filePath => {
     const text = path.basename(filePath)
 
     return {
@@ -25,11 +25,11 @@ const generateIndex = (directory, htmlFilePaths, subDirPaths, options) => {
 }
 
 const generateIndexes = (files, options = { contentTitle: '' }) => {
-  const htmlFilePaths = files
+  const supportedFilePaths = files
     .map(file => file.relativePath)
-    .filter(relativePath => path.extname(relativePath) === '.html')
+    .filter(relativePath => path.extname(relativePath) === '.html' || path.extname(relativePath) === '.pdf')
 
-  const directories = getDirectories(htmlFilePaths)
+  const directories = getDirectories(supportedFilePaths)
   // If we have not got a 'root' folder, then add one.
   // TODO: Refactor this so it is not needed (maybe?)
   if (!directories.includes('')) {
@@ -37,7 +37,7 @@ const generateIndexes = (files, options = { contentTitle: '' }) => {
   }
 
   const indexes = directories.map(directory => {
-    const filesInDir = filterFilesInDirectory(htmlFilePaths, directory)
+    const filesInDir = filterFilesInDirectory(supportedFilePaths, directory)
     const subDirsInDir = filterDirectoriesInDirectory(directories, directory)
     const indexPath = directory ? `${directory}/index.html` : 'index.html'
 

--- a/test/unit/__snapshots__/generate-indexes.test.js.snap
+++ b/test/unit/__snapshots__/generate-indexes.test.js.snap
@@ -753,6 +753,126 @@ exports[`Generate Indexes with the correct html to match snapshot with a content
 </html>
 `;
 
+exports[`Generate Indexes with the correct html to match snapshot with a pdf file 1`] = `
+<html lang="en"
+      style="min-height:100vh"
+      data-reactroot
+>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible"
+          content="IE=edge"
+    >
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1"
+    >
+    <title>
+      Morty Docs
+    </title>
+    <link rel="stylesheet"
+          href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+          integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
+          crossorigin="anonymous"
+    >
+    <link rel="stylesheet"
+          href="https://use.fontawesome.com/releases/v5.8.1/css/all.css"
+          integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf"
+          crossorigin="anonymous"
+    >
+  </head>
+  <body style="min-height:100vh">
+    <div style="min-height:75vh;padding-bottom:20px">
+      <div class="container"
+           style="border:none;border-radius:0;background-color:#000;height:60px;margin-bottom:0;width:100%;padding:1.142rem"
+      >
+        <nav>
+          <ol style="padding:0;list-style:none;display:flex;height:100%;align-items:center">
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs"
+              >
+                morty-docs
+              </a>
+            </li>
+            <li>
+              <span aria-hidden="true"
+                    style="margin:0 0.28rem;color:#ebebeb"
+              >
+                /
+              </span>
+              <a style="text-align:left;color:lightblue;font-size:2rem"
+                 href="/morty-docs/some-repo"
+              >
+                some-repo
+              </a>
+            </li>
+          </ol>
+        </nav>
+      </div>
+      <div class="container"
+           style="margin-top:10px"
+      >
+        <div class="row col-md-8 col-md-offset-2">
+          <ul class="list-unstyled">
+            <li class="index-list"
+                style="font-size:1.6em;border-bottom:solid black 1px;margin-bottom:10px"
+            >
+              <a href="foo1.html">
+                <i class="fas fa-file-alt">
+                </i>
+                <span style="margin-left:5px">
+                  foo1.html
+                </span>
+              </a>
+            </li>
+            <li class="index-list"
+                style="font-size:1.6em;border-bottom:solid black 1px;margin-bottom:10px"
+            >
+              <a href="foo2.pdf">
+                <i class="fas fa-file-alt">
+                </i>
+                <span style="margin-left:5px">
+                  foo2.pdf
+                </span>
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <footer style="bottom:0;width:100%;background-color:#f5f5f5;padding:0 15px;box-sizing:border-box;min-height:25vh;position:relative"
+            class="footer"
+    >
+      <div style="padding:1em 0 2em 0"
+           class="container"
+      >
+        <div class="row">
+          <div style="text-align:center"
+               class="col-md-4 col-md-offset-4"
+          >
+            <h3>
+              What is Morty-Docs?
+            </h3>
+            <p>
+              Link to
+              <a href="https://github.com/bbc/morty-docs">
+                Morty-docs
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>
+`;
+
 exports[`Generate Indexes with the correct html to match snapshot without a content title 1`] = `
 <html lang="en"
       style="min-height:100vh"

--- a/test/unit/generate-indexes.test.js
+++ b/test/unit/generate-indexes.test.js
@@ -136,4 +136,16 @@ describe('Generate Indexes with the correct html', () => {
 
     expect(actual[0].raw.toString()).toMatchSnapshot()
   })
+
+  it('to match snapshot with a pdf file', () => {
+    const input = [{
+      relativePath: 'foo1.html'
+    }, {
+      relativePath: 'foo2.pdf'
+    }]
+
+    const actual = generateIndexes(input, { basePath: 'morty-docs/some-repo' })
+
+    expect(actual[0].raw.toString()).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
🧐 What?

We have a use case where documentation stored on GitHub includes PDFs. Providing links to these PDFs is a simple way of making these available via Morty, as they can either be rendered by the browser (where supported) or downloaded.

🛠 How

Include PDF files as well as HTML files when generating index pages.
