### PR TITLE
folders are now sorted both lexically and reverse chronologically

### DIFF
--- a/src/helpers/filter-dirs-in-dir.js
+++ b/src/helpers/filter-dirs-in-dir.js
@@ -1,3 +1,5 @@
+const { sortArrayByDate } = require('../../src/helpers/sort-array-by-date')
+
 const filterDirs = (directoryPaths, directory) => {
   const directoryArray = []
   const nestedDirFolders = directoryPaths.filter(directoryPath => directoryPath.includes(directory) && !directoryPath.startsWith(directory) && directoryPath !== directory)
@@ -9,7 +11,12 @@ const filterDirs = (directoryPaths, directory) => {
     ? directoryPath.replace(`${directory}/`, '') : directoryPath)
   if (rootDir.length) directoryArray.push(rootDir)
   // if directory path starts with the config folder then remove the directory from the path
-  return directoryArray.flat()
+  // sort array here
+  let sortedDirectoryArray = directoryArray
+  if (sortedDirectoryArray.length) {
+    sortedDirectoryArray.map((arr) => sortArrayByDate(arr))
+  }
+  return sortedDirectoryArray.flat()
 }
 
 module.exports = filterDirs

--- a/src/helpers/filter-files-in-dir.js
+++ b/src/helpers/filter-files-in-dir.js
@@ -1,8 +1,4 @@
-const dateRegex = /\d{4}-\d{2}-\d{2}/ // i.e. 2019-10-29
-
-function sortByDate (a, b) {
-  return a.match(dateRegex) && b.match(dateRegex) ? b.localeCompare(a) : a.localeCompare(b)
-}
+const { sortArrayByDate } = require('../../src/helpers/sort-array-by-date')
 
 const directoryDepth = path => path.split('/').length
 const isInRootDirectory = filePath => directoryDepth(filePath) === 1
@@ -10,5 +6,5 @@ const isIn = directory => filePath => filePath.startsWith(directory) && ((direct
 
 module.exports = (filePaths, directory) => {
   const isInSpecifiedDirectory = directory ? isIn(directory) : isInRootDirectory
-  return filePaths.filter(isInSpecifiedDirectory).sort(sortByDate)
+  return sortArrayByDate(filePaths.filter(isInSpecifiedDirectory))
 }

--- a/src/helpers/sort-array-by-date.js
+++ b/src/helpers/sort-array-by-date.js
@@ -1,0 +1,13 @@
+const dateRegex = /\d{4}-\d{2}-\d{2}/ // i.e. 2019-10-29
+
+function sortByDate (a, b) {
+  return a.match(dateRegex) && b.match(dateRegex) ? b.localeCompare(a) : a.localeCompare(b)
+}
+
+const sortArrayByDate = (arr) => {
+  return arr.sort(sortByDate)
+}
+
+module.exports = {
+  sortArrayByDate
+}

--- a/test/unit/__snapshots__/generate-indexes.test.js.snap
+++ b/test/unit/__snapshots__/generate-indexes.test.js.snap
@@ -69,22 +69,22 @@ exports[`Generate Indexes with the correct html The correct links are included i
             <li class="index-list"
                 style="font-size:1.6em;border-bottom:solid black 1px;margin-bottom:10px"
             >
-              <a href="folder/index.html">
+              <a href="docs/index.html">
                 <i class="fas fa-folder-open">
                 </i>
                 <span style="margin-left:5px">
-                  folder
+                  docs
                 </span>
               </a>
             </li>
             <li class="index-list"
                 style="font-size:1.6em;border-bottom:solid black 1px;margin-bottom:10px"
             >
-              <a href="docs/index.html">
+              <a href="folder/index.html">
                 <i class="fas fa-folder-open">
                 </i>
                 <span style="margin-left:5px">
-                  docs
+                  folder
                 </span>
               </a>
             </li>

--- a/test/unit/helpers/filter-dirs-in-dir.test.js
+++ b/test/unit/helpers/filter-dirs-in-dir.test.js
@@ -1,0 +1,41 @@
+const filterDirs = require('../../../src/helpers/filter-dirs-in-dir')
+
+describe('Given a list of root folders', () => {
+  test('output', () => {
+    const directoryPaths = ['test2', 'test1', 'test4', 'test3']
+    const directory = '' // root
+    const expectedOutput = ['test1', 'test2', 'test3', 'test4']
+    const output = filterDirs(directoryPaths, directory)
+    expect(output).toEqual(expectedOutput)
+  })
+})
+
+describe('Given a list of nested folders', () => {
+  test('When ', () => {
+    const directoryPaths = ['root/test2', 'root/test1', 'root/test4', 'root/test3']
+    const directory = '' // root
+    const expectedOutput = ['root/test1', 'root/test2', 'root/test3', 'root/test4']
+    const output = filterDirs(directoryPaths, directory)
+    expect(output).toEqual(expectedOutput)
+  })
+})
+
+describe('Given a multiple nested folders', () => {
+  test('It should only return the ones in the root2 directory', () => {
+    const directoryPaths = ['root/test2', 'root/test1', 'root2/test4', 'root2/test3']
+    const directory = 'root2'
+    const expectedOutput = ['test3', 'test4']
+    const output = filterDirs(directoryPaths, directory)
+    expect(output).toEqual(expectedOutput)
+  })
+})
+
+describe('Given a list of date folders', () => {
+  test('It should return them in date order lexically', () => {
+    const directoryPaths = ['2022-01-22-name', '2022-01-05-name', '2022-01-10-name']
+    const directory = ''
+    const expectedOutput = ['2022-01-22-name', '2022-01-10-name', '2022-01-05-name']
+    const output = filterDirs(directoryPaths, directory)
+    expect(output).toEqual(expectedOutput)
+  })
+})

--- a/test/unit/helpers/filter-files-in-dir.test.js
+++ b/test/unit/helpers/filter-files-in-dir.test.js
@@ -1,0 +1,21 @@
+const filterFiles = require('../../../src/helpers/filter-files-in-dir')
+
+describe('Given a list of root file names', () => {
+  test('output', () => {
+    const directoryPaths = ['test2', 'test1', 'test4', 'test3']
+    const directory = '' // root
+    const expectedOutput = ['test1', 'test2', 'test3', 'test4']
+    const output = filterFiles(directoryPaths, directory)
+    expect(output).toEqual(expectedOutput)
+  })
+})
+
+describe('Given a list of date file names', () => {
+  test('It should return them in date order lexically', () => {
+    const directoryPaths = ['2022-01-22-name', '2022-01-05-name', '2022-01-10-name']
+    const directory = ''
+    const expectedOutput = ['2022-01-22-name', '2022-01-10-name', '2022-01-05-name']
+    const output = filterFiles(directoryPaths, directory)
+    expect(output).toEqual(expectedOutput)
+  })
+})

--- a/test/unit/helpers/sort-array-by-date.test.js
+++ b/test/unit/helpers/sort-array-by-date.test.js
@@ -1,0 +1,19 @@
+const { sortArrayByDate } = require('../../../src/helpers/sort-array-by-date')
+
+describe('Given an array', () => {
+  test('it should sorted lexically (0-9 < a-z>)', () => {
+    const list = ['example1', '2018', '2017', 'test2']
+    const expectedOutput = ['2017', '2018', 'example1', 'test2']
+    const output = sortArrayByDate(list)
+    expect(output).toEqual(expectedOutput)
+  })
+})
+
+describe('Given an array that prefix dates in the name', () => {
+  test('it should sort it reverse chronologically', () => {
+    const list = ['2019-10-29-some-document', '2017-10-01-some-document', '2021-10-29-some-document', '2020-10-29-some-document']
+    const expectedOutput = ['2021-10-29-some-document', '2020-10-29-some-document', '2019-10-29-some-document', '2017-10-01-some-document']
+    const output = sortArrayByDate(list)
+    expect(output).toEqual(expectedOutput)
+  })
+})


### PR DESCRIPTION
🧐 What?
folders are now sorted both lexically and reverse chronologically

🛠 How
- Split out the sorting function from the filter-files-in-dir.js
- Used the new sort function in both filter-files-in-dir.js and filter-dirs-in-dir.js
- added unit tests for all these

🐞 Related issue 

[Issue 49](https://github.com/bbc/morty-docs/issues/49)
