### PR TITLE
fix relative paths for filter helpers

### DIFF
--- a/src/helpers/filter-dirs-in-dir.js
+++ b/src/helpers/filter-dirs-in-dir.js
@@ -1,4 +1,4 @@
-const { sortArrayByDate } = require('../../src/helpers/sort-array-by-date')
+const { sortArrayByDate } = require('./sort-array-by-date')
 
 const filterDirs = (directoryPaths, directory) => {
   const directoryArray = []

--- a/src/helpers/filter-files-in-dir.js
+++ b/src/helpers/filter-files-in-dir.js
@@ -1,4 +1,4 @@
-const { sortArrayByDate } = require('../../src/helpers/sort-array-by-date')
+const { sortArrayByDate } = require('./sort-array-by-date')
 
 const directoryDepth = path => path.split('/').length
 const isInRootDirectory = filePath => directoryDepth(filePath) === 1


### PR DESCRIPTION
🧐 What?
fix relative paths for filter helpers because the usage in morty breaks the tests

🛠 How
Change relative path url in the require
