### PR TITLE
Fixed bug with multiple relative links only replaces the last link on that line.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
     "start": "rm -rf www && npm run build -- --source-maps && node run.js && npx http-server www",
     "build": "rm -rf build && mkdir build && babel src --out-dir build",
     "build-watch": "npm run build -- --source-maps --watch",
-    "test": "jest --runInBand --outputFile test-results.json --json && npm run lint",
+    "test": "jest --runInBand --outputFile test-results.json --json",
     "coverage": "jest --coverage --runInBand && open coverage/lcov-report/index.html",
     "lint": "standard",
+    "posttest": "npm run lint",
     "prepare": "npm run build",
     "postversion": "git push origin main && git push --tags origin main"
   },

--- a/src/markdown-to-html-parser.js
+++ b/src/markdown-to-html-parser.js
@@ -7,6 +7,9 @@ const convertMdLinksToHtmlLinks = {
   regex: /<a href="([^:\n]*).md">/g, // exclude colon, so external links aren't converted
   replace: '<a href="$1.html">'
 }
+// Due to the converter the global replace on links is broken so if you have multiple links per line we need multiple matchers or they don't get replaced.
+const maxLinksPerLine = 10
+const convertMultipleMdLinksToHtmlLinks =  new Array(maxLinksPerLine).fill().map(x => convertMdLinksToHtmlLinks);
 
 const headingExtension = {
   type: 'output',
@@ -46,7 +49,7 @@ const createParser = (options) => {
 
   const parser = new showdown.Converter({
     extensions: [
-      convertMdLinksToHtmlLinks,
+      convertMultipleMdLinksToHtmlLinks,
       addBasePathToRootLinks,
       headingExtension,
       ...bindings

--- a/src/markdown-to-html-parser.js
+++ b/src/markdown-to-html-parser.js
@@ -9,7 +9,7 @@ const convertMdLinksToHtmlLinks = {
 }
 // Due to the converter the global replace on links is broken so if you have multiple links per line we need multiple matchers or they don't get replaced.
 const maxLinksPerLine = 10
-const convertMultipleMdLinksToHtmlLinks =  new Array(maxLinksPerLine).fill().map(x => convertMdLinksToHtmlLinks);
+const convertMultipleMdLinksToHtmlLinks = new Array(maxLinksPerLine).fill().map(x => convertMdLinksToHtmlLinks)
 
 const headingExtension = {
   type: 'output',

--- a/test/unit/__snapshots__/generate-indexes.test.js.snap
+++ b/test/unit/__snapshots__/generate-indexes.test.js.snap
@@ -179,11 +179,11 @@ sup {
       </a>
       <br>
       Page generated on
-      18
+      1
       <sup>
-        th
+        st
       </sup>
-      July
+      December
       2022
     </footer>
   </body>
@@ -341,11 +341,11 @@ sup {
       </a>
       <br>
       Page generated on
-      18
+      1
       <sup>
-        th
+        st
       </sup>
-      July
+      December
       2022
     </footer>
   </body>
@@ -503,11 +503,11 @@ sup {
       </a>
       <br>
       Page generated on
-      18
+      1
       <sup>
-        th
+        st
       </sup>
-      July
+      December
       2022
     </footer>
   </body>
@@ -677,11 +677,11 @@ sup {
       </a>
       <br>
       Page generated on
-      18
+      1
       <sup>
-        th
+        st
       </sup>
-      July
+      December
       2022
     </footer>
   </body>
@@ -847,11 +847,11 @@ sup {
       </a>
       <br>
       Page generated on
-      18
+      1
       <sup>
-        th
+        st
       </sup>
-      July
+      December
       2022
     </footer>
   </body>
@@ -1022,11 +1022,11 @@ sup {
       </a>
       <br>
       Page generated on
-      18
+      1
       <sup>
-        th
+        st
       </sup>
-      July
+      December
       2022
     </footer>
   </body>
@@ -1192,11 +1192,11 @@ sup {
       </a>
       <br>
       Page generated on
-      18
+      1
       <sup>
-        th
+        st
       </sup>
-      July
+      December
       2022
     </footer>
   </body>
@@ -1362,11 +1362,11 @@ sup {
       </a>
       <br>
       Page generated on
-      18
+      1
       <sup>
-        th
+        st
       </sup>
-      July
+      December
       2022
     </footer>
   </body>

--- a/test/unit/__snapshots__/transform-content.test.js.snap
+++ b/test/unit/__snapshots__/transform-content.test.js.snap
@@ -290,11 +290,11 @@ sup {
       </a>
       <br>
       Page generated on
-      18
+      1
       <sup>
-        th
+        st
       </sup>
-      July
+      December
       2022
     </footer>
   </body>
@@ -591,11 +591,11 @@ sup {
       </a>
       <br>
       Page generated on
-      18
+      1
       <sup>
-        th
+        st
       </sup>
-      July
+      December
       2022
     </footer>
   </body>
@@ -892,11 +892,11 @@ sup {
       </a>
       <br>
       Page generated on
-      18
+      1
       <sup>
-        th
+        st
       </sup>
-      July
+      December
       2022
     </footer>
   </body>
@@ -1184,11 +1184,11 @@ sup {
       </a>
       <br>
       Page generated on
-      18
+      1
       <sup>
-        th
+        st
       </sup>
-      July
+      December
       2022
     </footer>
   </body>
@@ -1473,11 +1473,11 @@ sup {
       </a>
       <br>
       Page generated on
-      18
+      1
       <sup>
-        th
+        st
       </sup>
-      July
+      December
       2022
     </footer>
   </body>
@@ -1751,11 +1751,11 @@ sup {
       </a>
       <br>
       Page generated on
-      18
+      1
       <sup>
-        th
+        st
       </sup>
-      July
+      December
       2022
     </footer>
   </body>

--- a/test/unit/markdown-to-html-parser.test.js
+++ b/test/unit/markdown-to-html-parser.test.js
@@ -50,4 +50,13 @@ describe('Markdown Parser', () => {
 
     expect(actual).toEqual(expected)
   })
+  it('should replace multiple relative links per line', () => {
+    const markdown = '[here](./publishing-your-repo.md)[here](./publishing-your-repo.md)[here](./publishing-your-repo.md)'
+
+    const actual = parseToHtml(markdown)
+
+    const expected = '<p><a href=\"./publishing-your-repo.html\">here</a><a href=\"./publishing-your-repo.html\">here</a><a href=\"./publishing-your-repo.html\">here</a></p>'
+
+    expect(actual).toEqual(expected)
+  })
 })

--- a/test/unit/markdown-to-html-parser.test.js
+++ b/test/unit/markdown-to-html-parser.test.js
@@ -55,7 +55,7 @@ describe('Markdown Parser', () => {
 
     const actual = parseToHtml(markdown)
 
-    const expected = '<p><a href=\"./publishing-your-repo.html\">here</a><a href=\"./publishing-your-repo.html\">here</a><a href=\"./publishing-your-repo.html\">here</a></p>'
+    const expected = '<p><a href="./publishing-your-repo.html">here</a><a href="./publishing-your-repo.html">here</a><a href="./publishing-your-repo.html">here</a></p>'
 
     expect(actual).toEqual(expected)
   })


### PR DESCRIPTION
Fixed bug with multiple relative links only replaces the last link on that line.

🧐 What?

![Screenshot 2022-12-01 at 14 41 58](https://user-images.githubusercontent.com/24595810/205088103-e8dc5d2d-eb05-4f0e-ba16-eea84183c7e6.png)

🛠 How

Reapply replacements multiple times fixes it. I believe this is a bug with showdown.Converter probably loosing the global regex flag but this is the simplest fix.


