### PR TITLE
Use Jest fake timers to mock the JS Date object

### DIFF
--- a/test/unit/__snapshots__/generate-indexes.test.js.snap
+++ b/test/unit/__snapshots__/generate-indexes.test.js.snap
@@ -183,8 +183,8 @@ sup {
       <sup>
         st
       </sup>
-      December
-      2022
+      April
+      2020
     </footer>
   </body>
 </html>
@@ -345,8 +345,8 @@ sup {
       <sup>
         st
       </sup>
-      December
-      2022
+      April
+      2020
     </footer>
   </body>
 </html>
@@ -507,8 +507,8 @@ sup {
       <sup>
         st
       </sup>
-      December
-      2022
+      April
+      2020
     </footer>
   </body>
 </html>
@@ -681,8 +681,8 @@ sup {
       <sup>
         st
       </sup>
-      December
-      2022
+      April
+      2020
     </footer>
   </body>
 </html>
@@ -851,8 +851,8 @@ sup {
       <sup>
         st
       </sup>
-      December
-      2022
+      April
+      2020
     </footer>
   </body>
 </html>
@@ -1026,8 +1026,8 @@ sup {
       <sup>
         st
       </sup>
-      December
-      2022
+      April
+      2020
     </footer>
   </body>
 </html>
@@ -1196,8 +1196,8 @@ sup {
       <sup>
         st
       </sup>
-      December
-      2022
+      April
+      2020
     </footer>
   </body>
 </html>
@@ -1366,8 +1366,8 @@ sup {
       <sup>
         st
       </sup>
-      December
-      2022
+      April
+      2020
     </footer>
   </body>
 </html>

--- a/test/unit/__snapshots__/transform-content.test.js.snap
+++ b/test/unit/__snapshots__/transform-content.test.js.snap
@@ -294,8 +294,8 @@ sup {
       <sup>
         st
       </sup>
-      December
-      2022
+      April
+      2020
     </footer>
   </body>
 </html>
@@ -595,8 +595,8 @@ sup {
       <sup>
         st
       </sup>
-      December
-      2022
+      April
+      2020
     </footer>
   </body>
 </html>
@@ -896,8 +896,8 @@ sup {
       <sup>
         st
       </sup>
-      December
-      2022
+      April
+      2020
     </footer>
   </body>
 </html>
@@ -1188,8 +1188,8 @@ sup {
       <sup>
         st
       </sup>
-      December
-      2022
+      April
+      2020
     </footer>
   </body>
 </html>
@@ -1477,8 +1477,8 @@ sup {
       <sup>
         st
       </sup>
-      December
-      2022
+      April
+      2020
     </footer>
   </body>
 </html>
@@ -1755,8 +1755,8 @@ sup {
       <sup>
         st
       </sup>
-      December
-      2022
+      April
+      2020
     </footer>
   </body>
 </html>

--- a/test/unit/generate-indexes.test.js
+++ b/test/unit/generate-indexes.test.js
@@ -1,5 +1,14 @@
 const generateIndexes = require('../../src/generate-indexes.js')
 
+beforeAll(() => {
+  jest.useFakeTimers('modern')
+  jest.setSystemTime(new Date(2020, 3, 1))
+})
+
+afterAll(() => {
+  jest.useRealTimers()
+})
+
 describe('Generating indexes', () => {
   it('returns an index page for the "root" folder', () => {
     const input = [{

--- a/test/unit/transform-content.test.js
+++ b/test/unit/transform-content.test.js
@@ -1,5 +1,14 @@
 const transformContent = require('../../src/transform-content.js')
 
+beforeAll(() => {
+  jest.useFakeTimers('modern')
+  jest.setSystemTime(new Date(2020, 3, 1))
+})
+
+afterAll(() => {
+  jest.useRealTimers()
+})
+
 const options = {
   contentTitle: 'Some Title',
   basePath: '/morty-docs/some-repo'


### PR DESCRIPTION
🧐 What?
Use Jest fake timers to mock the JS Date object

Why?
Every time you run the tests it will fail the snapshots because the page generated timestamp is always todays date , so if we mock it we can fix it to a specific day
