### PR TITLE
Fix hash links which are not replaced by previous regex.

### DIFF
--- a/src/markdown-to-html-parser.js
+++ b/src/markdown-to-html-parser.js
@@ -9,6 +9,14 @@ const convertMdLinksToHtmlLinks = {
   replace: '<a href="$1.html">'
 }
 
+// Replace hash links with .html e.g. page.md#Title becomes page.html#Title.
+const convertMdHashLinksToHtmlLinks = {
+  type: 'output',
+  regex: /<a href="([^:\n]*?).md#(.*?)">/g,
+  // exclude colon, so external links aren't converted
+  replace: '<a href="$1.html#$2">'
+}
+
 const headingExtension = {
   type: 'output',
   regex: /<(h[123456]) id="(.*)">(.*)<\/\1>/g,
@@ -48,6 +56,7 @@ const createParser = (options) => {
   const parser = new showdown.Converter({
     extensions: [
       convertMdLinksToHtmlLinks,
+      convertMdHashLinksToHtmlLinks,
       addBasePathToRootLinks,
       headingExtension,
       ...bindings

--- a/test/unit/markdown-to-html-parser.test.js
+++ b/test/unit/markdown-to-html-parser.test.js
@@ -59,4 +59,14 @@ describe('Markdown Parser', () => {
 
     expect(actual).toEqual(expected)
   })
+  
+  it('should replace multiple hash links per line', () => {
+    const markdown = '[here](./link1.md#Section1)[here](./link2.md#Section2)[here](./link3.md#Section3)'
+
+    const actual = parseToHtml(markdown)
+
+    const expected = '<p><a href="./link1.html#Section1">here</a><a href="./link2.html#Section2">here</a><a href="./link3.html#Section3">here</a></p>'
+
+    expect(actual).toEqual(expected)
+  })
 })

--- a/test/unit/markdown-to-html-parser.test.js
+++ b/test/unit/markdown-to-html-parser.test.js
@@ -59,7 +59,7 @@ describe('Markdown Parser', () => {
 
     expect(actual).toEqual(expected)
   })
-  
+
   it('should replace multiple hash links per line', () => {
     const markdown = '[here](./link1.md#Section1)[here](./link2.md#Section2)[here](./link3.md#Section3)'
 


### PR DESCRIPTION
🧐 What?

Our morty docs have some .md hash links not replaced with .html which result in errors when you click them.
<img width="1129" alt="image" src="https://user-images.githubusercontent.com/24595810/205925537-7f94c11d-435d-4b5c-9529-40c3bba9e526.png">

This is due to the original regex not supporting this

<img width="999" alt="Screenshot 2022-12-06 at 13 27 08" src="https://user-images.githubusercontent.com/24595810/205924959-91d19f56-cd3d-40e3-a400-6adf973801fd.png">


🛠 How

I have fixed the hash links with another regex replacement similar to previous one but with second capture group `/<a href="([^:\n]*?).md#(.*?)">/g` so that we can replace hash links correctly.
<img width="999" alt="image" src="https://user-images.githubusercontent.com/24595810/205924449-7b06fcbe-c3db-48e1-9b9d-95a08a338326.png">

👀 See <!--[optional]-->

Unit test case for hash links
