### PR TITLE
Be more strict with id capture group when creating header links

### DIFF
--- a/default-md-files/folder/subFolder/subFile.md
+++ b/default-md-files/folder/subFolder/subFile.md
@@ -1,1 +1,1 @@
-## This is a file in a sub folder
+## This is a file in a <em id="234">sub</em> folder

--- a/src/markdown-to-html-parser.js
+++ b/src/markdown-to-html-parser.js
@@ -19,7 +19,7 @@ const convertMdHashLinksToHtmlLinks = {
 
 const headingExtension = {
   type: 'output',
-  regex: /<(h[123456]) id="(.*)">(.*)<\/\1>/g,
+  regex: /<(h[123456]) id="([^"]+)">(.*)<\/\1>/g,
   replace: '<$1 id="$2"><a href="#$2">$3</a></$1>'
 }
 

--- a/test/unit/markdown-to-html-parser.test.js
+++ b/test/unit/markdown-to-html-parser.test.js
@@ -31,6 +31,16 @@ describe('Markdown Parser', () => {
     expect(actual.includes(expected)).toBe(true)
   })
 
+  it('creates anchor link for headings even with nested HTML content', () => {
+    const markdown = '# Heading <em id="123">with style!</em>'
+
+    const actual = parseToHtml(markdown)
+
+    const expected = '<h1 id="heading-em-id123with-styleem"><a href="#heading-em-id123with-styleem">Heading <em id="123">with style!</em></a></h1>'
+
+    expect(actual).toMatch(expected)
+  })
+
   it('creates an html link from an md link', () => {
     const markdown = '[here](./docs/user/publishing-your-repo.md)\n[here](./docs/user/publishing-another-repo.md)'
 


### PR DESCRIPTION
🧐 What?

- An HTML element within a heading that has an `id` (e.g. an image) can get repeated in the HTML output
- This is because the `id` capture group isn't strict enough

🛠 How

- Make the `id` capture group more strict so that it stops at the first `"` character

👀 See 

Try adding an image to a header and see that it comes out twice:

<img width="806" alt="image" src="https://github.com/bbc/morty-docs/assets/10939697/b5833691-0c17-4410-ae8f-8c690f6918ee">

🐞 Related issue

I haven't raised one, but happy to....
