### PR TITLE
Add support for mermaid diagrams

### DIFF
--- a/src/markdown-to-html-parser.js
+++ b/src/markdown-to-html-parser.js
@@ -16,7 +16,7 @@ const parseToHTML = (markdown, options = {}) => {
   // const parser = createParser(options)
   // return parser.makeHtml(markdown)
   const basePath = normaliseBasePath(options.basePath)
-  let hasMermaid = false;
+  let hasMermaid = false
 
   function flattenHeading (text) {
     // To match showdown behaviour
@@ -63,7 +63,7 @@ const parseToHTML = (markdown, options = {}) => {
       const title = type.charAt(0).toUpperCase() + type.slice(1).toLowerCase()
       return `<blockquote class="markdown-alert markdown-alert-${type}"><p><strong>${title}</strong></p><p>${content}</p></blockquote>`
     },
-    code ({ text, lang, escaped}) {
+    code ({ text, lang, escaped }) {
       if (lang === 'mermaid') {
         try {
           hasMermaid = true

--- a/src/markdown-to-html-parser.js
+++ b/src/markdown-to-html-parser.js
@@ -1,4 +1,3 @@
-// const showdown = require('showdown')
 const { marked } = require('marked')
 const emoji = require('node-emoji')
 
@@ -17,6 +16,7 @@ const parseToHTML = (markdown, options = {}) => {
   // const parser = createParser(options)
   // return parser.makeHtml(markdown)
   const basePath = normaliseBasePath(options.basePath)
+  let hasMermaid = false;
 
   function flattenHeading (text) {
     // To match showdown behaviour
@@ -62,6 +62,18 @@ const parseToHTML = (markdown, options = {}) => {
       content = content.replace(/^<br>/, '')
       const title = type.charAt(0).toUpperCase() + type.slice(1).toLowerCase()
       return `<blockquote class="markdown-alert markdown-alert-${type}"><p><strong>${title}</strong></p><p>${content}</p></blockquote>`
+    },
+    code ({ text, lang, escaped}) {
+      if (lang === 'mermaid') {
+        try {
+          hasMermaid = true
+          return `<div class="mermaid">${text}</div>`
+        } catch (error) {
+          console.error('Error rendering Mermaid diagram:', error)
+          return marked.Renderer.prototype.code.call(this, { text, lang, escaped })
+        }
+      }
+      return marked.Renderer.prototype.code.call(this, { text, lang, escaped })
     }
   }
 
@@ -77,6 +89,10 @@ const parseToHTML = (markdown, options = {}) => {
   html = html.replace(/<li>(<input.*)<\/li>/g, '<li class="task-list-item">$1</li>') // add class for list items (must have input at beginning)
   html = html.replace(/<a href="\/([^:\n]*)">/g, `<a href="${basePath}/$1">`) // addBasePathToRootLinks
   html = html.replace(/<link(.+)href="\/([^:\n]*)"(.*)\/>/g, `<link$1href="${basePath}/$2"$3/>`) // addBasePathToLinkHrefs
+
+  if (hasMermaid) {
+    html = `<script src="/morty-docs/mermaid.min.js" type="module"></script>\n<script>mermaid.initialize({ startOnLoad: true });</script>\n${html}`
+  }
 
   const withEmoji = emoji.emojify(html) // convert emoji shortcodes to unicode e.g. :warning:
 

--- a/src/page-renderers/MortyPage.jsx
+++ b/src/page-renderers/MortyPage.jsx
@@ -187,6 +187,23 @@ const contentStyles = `
   border-top: 1px solid #ddd;
 }
 
+.content .mermaid {
+  visibility: hidden;
+
+  &:before {
+    content: 'Rendering diagram...';
+    visibility: visible;
+  }
+
+  &[data-processed] {
+    visibility: visible;
+
+    &:before {
+      display: none;
+    }
+  }
+}
+
 `
 
 const MortyPage = ({ relPath, body, options }) => {

--- a/src/page-renderers/MortyPage.jsx
+++ b/src/page-renderers/MortyPage.jsx
@@ -189,10 +189,15 @@ const contentStyles = `
 
 .content .mermaid {
   visibility: hidden;
+  position: relative;
 
   &:before {
     content: 'Rendering diagram...';
     visibility: visible;
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
   }
 
   &[data-processed] {

--- a/test/unit/__snapshots__/transform-content.test.js.snap
+++ b/test/unit/__snapshots__/transform-content.test.js.snap
@@ -219,6 +219,28 @@ sup {
   border-top: 1px solid #ddd;
 }
 
+.content .mermaid {
+  visibility: hidden;
+  position: relative;
+
+  &:before {
+    content: 'Rendering diagram...';
+    visibility: visible;
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  &[data-processed] {
+    visibility: visible;
+
+    &:before {
+      display: none;
+    }
+  }
+}
+
 </style></head><body style="min-height:100vh;font-family:&quot;Helvetica Neue&quot;,Helvetica,Arial,sans-serif;color:#333;background-color:#fff"><div style="min-height:75vh;padding-bottom:20px"><div style="border:none;border-radius:0;background-color:#000;margin-bottom:0;width:100%"><nav><ol style="padding:1rem;list-style:none;display:flex;align-items:center"><li><span aria-hidden="true" style="margin:0 0.28rem;color:#ebebeb">/</span><a style="text-align:left;color:lightblue;font-size:1.5rem;text-decoration:none" href="/morty-docs">morty-docs</a></li><li><span aria-hidden="true" style="margin:0 0.28rem;color:#ebebeb">/</span><a style="text-align:left;color:lightblue;font-size:1.5rem;text-decoration:none" href="/morty-docs/some-repo">some-repo</a></li></ol></nav></div><div class="content"><h1 id="title-of-simple-contentmd"><a href="#title-of-simple-contentmd">Title of simple-content.md</a></h1><p><a href="docs/file-to-publish.html">Relative link to MD in docs directory</a><br><a href="/morty-docs/some-repo/docs/file-to-publish.html">Root link to MD in docs directory</a></p></div></div><footer style="bottom:0;width:100%;background-color:#f5f5f5;box-sizing:border-box;min-height:25vh;position:relative;text-align:center;padding:1em 0 2em 0;line-height:1.5rem"><a href="https://github.com/bbc/morty-docs" style="color:#337ab7">Morty-Docs on github</a><br/>Page generated on <!-- -->1<sup>st</sup> <!-- -->April<!-- --> <!-- -->2020</footer></body></html>"
 `;
 
@@ -439,6 +461,28 @@ sup {
   line-height: 1.42857143;
   vertical-align: top;
   border-top: 1px solid #ddd;
+}
+
+.content .mermaid {
+  visibility: hidden;
+  position: relative;
+
+  &:before {
+    content: 'Rendering diagram...';
+    visibility: visible;
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  &[data-processed] {
+    visibility: visible;
+
+    &:before {
+      display: none;
+    }
+  }
 }
 
 </style></head><body style="min-height:100vh;font-family:&quot;Helvetica Neue&quot;,Helvetica,Arial,sans-serif;color:#333;background-color:#fff"><div style="min-height:75vh;padding-bottom:20px"><div style="border:none;border-radius:0;background-color:#000;margin-bottom:0;width:100%"><nav><ol style="padding:1rem;list-style:none;display:flex;align-items:center"><li><span aria-hidden="true" style="margin:0 0.28rem;color:#ebebeb">/</span><a style="text-align:left;color:lightblue;font-size:1.5rem;text-decoration:none" href="/morty-docs">morty-docs</a></li><li><span aria-hidden="true" style="margin:0 0.28rem;color:#ebebeb">/</span><a style="text-align:left;color:lightblue;font-size:1.5rem;text-decoration:none" href="/morty-docs/some-repo">some-repo</a></li></ol></nav></div><div class="content"><p>One line of plain text</p></div></div><footer style="bottom:0;width:100%;background-color:#f5f5f5;box-sizing:border-box;min-height:25vh;position:relative;text-align:center;padding:1em 0 2em 0;line-height:1.5rem"><a href="https://github.com/bbc/morty-docs" style="color:#337ab7">Morty-Docs on github</a><br/>Page generated on <!-- -->1<sup>st</sup> <!-- -->April<!-- --> <!-- -->2020</footer></body></html>"


### PR DESCRIPTION
🧐 What?

- There is an existing feature request for Mermaid diagram support: https://github.com/bbc/morty/issues/308
- This Pull Request relies on https://github.com/bbc/morty/pull/353 
- Once merged, any Mermaid code blocks will be rendered as diagrams rather than the source code

🛠 How

When a Mermaid code block is found:

- The code block is given the `mermaid` class so the Mermaid JS can detect the diagrams to be rendered
- The Mermaid JS bundle is imported from `/morty-docs/mermaid.min.js` (see https://github.com/bbc/morty/pull/353 )
- The Mermaid library is used to trigger an auto-render of the diagrams

CSS rules ensure that:

- A loading message is displayed on initial page load
- The diagram source code is hidden during render
- `visibility: hidden` is used to reserve some space (but not the _right_ amount of space) while the diagram renders to avoid at least some of the layout shift when the diagrams render

👀 See <!--[optional]-->

Here's an example showing the loading state and the rendered diagrams from https://github.com/bbc/iplayer-catalogue/blob/main/programme/docs/long-form-video/episode-ingest-scenarios.md (existing Morty page: https://broxy.tools.bbc.co.uk/morty-docs/iplayer-catalogue/programme/docs/long-form-video/episode-ingest-scenarios.html )

<img width="1713" height="941" alt="morty-mermaid" src="https://github.com/user-attachments/assets/7d80027e-7391-4fcf-9024-a10cf915102f" />

<!--[Describe or add screenshots]-->

🐞 Related issue <!--[optional]-->

https://github.com/bbc/morty/issues/308