### PR TITLE
Add syntax highlighting imports if a markdown file contains code blocks with languages set

### DIFF
--- a/src/markdown-to-html-parser.js
+++ b/src/markdown-to-html-parser.js
@@ -17,7 +17,7 @@ const parseToHTML = (markdown, options = {}) => {
   // const parser = createParser(options)
   // return parser.makeHtml(markdown)
   const basePath = normaliseBasePath(options.basePath)
-  let hasCodeBlock = false;
+  let hasCodeBlock = false
 
   function flattenHeading (text) {
     // To match showdown behaviour
@@ -82,7 +82,6 @@ const parseToHTML = (markdown, options = {}) => {
   html = html.replace(/<li>(<input.*)<\/li>/g, '<li class="task-list-item">$1</li>') // add class for list items (must have input at beginning)
   html = html.replace(/<a href="\/([^:\n]*)">/g, `<a href="${basePath}/$1">`) // addBasePathToRootLinks
   html = html.replace(/<link(.+)href="\/([^:\n]*)"(.*)\/>/g, `<link$1href="${basePath}/$2"$3/>`) // addBasePathToLinkHrefs
-
 
   if (hasCodeBlock) {
     html = `<link rel="stylesheet" href="/morty-docs/highlightjs/styles/github.min.css" />

--- a/src/markdown-to-html-parser.js
+++ b/src/markdown-to-html-parser.js
@@ -98,7 +98,7 @@ const parseToHTML = (markdown, options = {}) => {
 ${html}
 <script>hljs.highlightAll();</script>`
   }
-  
+
   if (hasMermaid) {
     html = `<script src="/morty-docs/mermaid.min.js" type="module"></script>\n<script>mermaid.initialize({ startOnLoad: true });</script>\n${html}`
   }

--- a/src/markdown-to-html-parser.js
+++ b/src/markdown-to-html-parser.js
@@ -17,6 +17,7 @@ const parseToHTML = (markdown, options = {}) => {
   // const parser = createParser(options)
   // return parser.makeHtml(markdown)
   const basePath = normaliseBasePath(options.basePath)
+  let hasCodeBlock = false;
 
   function flattenHeading (text) {
     // To match showdown behaviour
@@ -62,6 +63,10 @@ const parseToHTML = (markdown, options = {}) => {
       content = content.replace(/^<br>/, '')
       const title = type.charAt(0).toUpperCase() + type.slice(1).toLowerCase()
       return `<blockquote class="markdown-alert markdown-alert-${type}"><p><strong>${title}</strong></p><p>${content}</p></blockquote>`
+    },
+    code ({ text, lang, escaped }) {
+      hasCodeBlock = Boolean(lang)
+      return marked.Renderer.prototype.code.call(this, { text, lang, escaped })
     }
   }
 
@@ -77,6 +82,14 @@ const parseToHTML = (markdown, options = {}) => {
   html = html.replace(/<li>(<input.*)<\/li>/g, '<li class="task-list-item">$1</li>') // add class for list items (must have input at beginning)
   html = html.replace(/<a href="\/([^:\n]*)">/g, `<a href="${basePath}/$1">`) // addBasePathToRootLinks
   html = html.replace(/<link(.+)href="\/([^:\n]*)"(.*)\/>/g, `<link$1href="${basePath}/$2"$3/>`) // addBasePathToLinkHrefs
+
+
+  if (hasCodeBlock) {
+    html = `<link rel="stylesheet" href="/morty-docs/highlightjs/styles/github.min.css" />
+<script src="/morty-docs/highlightjs/highlight.min.js"></script>
+${html}
+<script>hljs.highlightAll();</script>`
+  }
 
   const withEmoji = emoji.emojify(html) // convert emoji shortcodes to unicode e.g. :warning:
 

--- a/test/unit/markdown-to-html-parser.test.js
+++ b/test/unit/markdown-to-html-parser.test.js
@@ -207,4 +207,40 @@ describe('Markdown Parser', () => {
 
     expect(actual).toEqual(expected)
   })
+
+  it('should add syntax highlighting imports when code blocks are present', () => {
+    const markdown = 
+      '```js\n' +
+      'console.log(\'First code block!\');\n' +
+      '```\n' +
+      '```js\n' +
+      'console.log(\'Second code block!\');\n' +
+      '```'
+
+    const actual = parseToHtml(markdown)
+    const expected =
+      `
+<link rel="stylesheet" href="/morty-docs/highlightjs/styles/github.min.css" />
+<script src="/morty-docs/highlightjs/highlight.min.js"></script>
+<pre><code class="language-js">console.log(&#39;First code block!&#39;);
+</code></pre>
+<pre><code class="language-js">console.log(&#39;Second code block!&#39;);
+</code></pre>
+<script>hljs.highlightAll();</script>`.trim()
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('should not add syntax highlighting imports when no code block has a language', () => {
+    const markdown = 
+      '```\n' +
+      'console.log(\'Hello, world!\');\n' +
+      '```'
+
+    const actual = parseToHtml(markdown)
+    const expected =
+      '<pre><code>console.log(&#39;Hello, world!&#39;);\n</code></pre>'
+
+    expect(actual).toEqual(expected)
+  })
 })

--- a/test/unit/markdown-to-html-parser.test.js
+++ b/test/unit/markdown-to-html-parser.test.js
@@ -209,7 +209,7 @@ describe('Markdown Parser', () => {
   })
 
   it('should add syntax highlighting imports when code blocks are present', () => {
-    const markdown = 
+    const markdown =
       '```js\n' +
       'console.log(\'First code block!\');\n' +
       '```\n' +
@@ -232,7 +232,7 @@ describe('Markdown Parser', () => {
   })
 
   it('should not add syntax highlighting imports when no code block has a language', () => {
-    const markdown = 
+    const markdown =
       '```\n' +
       'console.log(\'Hello, world!\');\n' +
       '```'


### PR DESCRIPTION
🧐 What?

- Adds client-side syntax highlighting for code blocks in Markdown files
- This will automatically add syntax highlighting to all relevant pages without the need for client opt-ins

🛠 How

- If a page has one or more code blocks with a language, import tags are added for HighlightJS (these are managed in / provided by `morty`)

👀 See <!--[optional]-->

<img width="1055" height="681" alt="image" src="https://github.com/user-attachments/assets/1306b09c-f588-414b-b4ab-46bc9a37251a" />
