### PR TITLE
Fix mermaid console errors

### DIFF
--- a/src/markdown-to-html-parser.js
+++ b/src/markdown-to-html-parser.js
@@ -100,7 +100,7 @@ ${html}
   }
 
   if (hasMermaid) {
-    html = `<script src="/morty-docs/mermaid.min.js" type="module"></script>\n<script>mermaid.initialize({ startOnLoad: true });</script>\n${html}`
+    html = `<script src="/morty-docs/mermaid.min.js"></script>\n<script>mermaid.initialize({ startOnLoad: true });</script>\n${html}`
   }
 
   const withEmoji = emoji.emojify(html) // convert emoji shortcodes to unicode e.g. :warning:


### PR DESCRIPTION
🧐 What?

Currently when a Mermaid diagram is included in the page the following errors can be seen in the console:

```
Uncaught ReferenceError: mermaid is not defined
Uncaught TypeError: Cannot read properties of undefined (reading 'mermaid')
```

Screenshot:

<img width="403" height="98" alt="image" src="https://github.com/user-attachments/assets/5093e753-4db3-4288-aadc-40d60d339b89" />

This is because the `mermaid.min.js` bundle is imported as an ES Module (using `type="module"`) but it is _expecting_ to be imported as a "classic script". When imported as a module, the `mermaid` global object fails to be set and the mermaid bundle throws an error. All diagrams still render successfully, however.

An ESM version of Mermaid does exist but is difficult to use because:

- The NPM package does not include a single-file ESM bundle — it's split across multiple files which would all need to be uploaded to S3
- The CDN distribution _does_ have a single-file ESM bundle but using this makes version management more difficult than using the NPM package (and would mean that tools like dependabot wouldn't be able to monitor vulnerabilities for the Mermaid dependency).

🛠 How

Removing the `type` attribute from the Mermaid `<script>` tag eliminates the console errors
